### PR TITLE
fix: pass current color to setColor when used as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ color.rgb // { r: 34, g: 114, b: 235 }
 color.rgba // { r: 34, g: 114, b: 235, a: 1 }
 
 const [color] = useColor('rgb(34, 114, 235)')
-color.string.hex // #2272eb
+color.strings.hex // #2272eb
 
 const [color] = useColor('rgba(34, 114, 235, 0.5)')
-color.string.hex // #2272eb80
+color.strings.hex // #2272eb80
 color.rgb // { r: 34, g: 114, b: 235 }
 color.rgba // { r: 34, g: 114, b: 235, a: 0.5 }
 ```
@@ -45,9 +45,9 @@ color.rgba // { r: 34, g: 114, b: 235, a: 0.5 }
 ```tsx
 const [color] = useColor({ r: 255, g: 255, b: 255 })
 
-color.string.hex // '#ffffff'
-color.string.rgb // 'rgb(255, 255, 255)'
-color.string.rgba // 'rgb(255, 255, 255, 1)'
+color.strings.hex // '#ffffff'
+color.strings.rgb // 'rgb(255, 255, 255)'
+color.strings.rgba // 'rgb(255, 255, 255, 1)'
 ```
 
 ### Stringify Options

--- a/src/useColor.ts
+++ b/src/useColor.ts
@@ -25,8 +25,7 @@ export const useColor = <Str extends string>(
         | ((prevColor: RgbaObject) => ColorInput<NewString>),
     ) => {
       if (typeof nextColor === 'function') {
-        const nextColorInput = nextColor(color.rgba)
-        setColor(parseColor(nextColorInput))
+        setColor((currentColor) => parseColor(nextColor(currentColor.rgba)))
         return
       }
       setColor(parseColor(nextColor, config))


### PR DESCRIPTION
Currently, there is a bug in the library when `setColor` takes a function: the callback param is always the initial color.
A reproducible example can be seen at [this sandbox](https://codesandbox.io/s/use-color-bug-demo-gwot6?file=/src/App.js:293-319).

This PR solves the issue by getting the current color from the internal `setState` function.

Also, I fixed some typos in the README related to `color.strings` missing a `s`.