### PR TITLE
docs(typo): modify Compile-time Type Checking Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ color.rgb // { r: 144, g: 194, b: 255 }
 ```diff
 + useColor('#00fffa')
 - useColor('#00ffzz')
-// Argument of type '"#00ffzaz"' is not assignable to parameter of type '...'.ts(2345)
+// Argument of type '"#00ffzz"' is not assignable to parameter of type '...'.ts(2345)
 
 + useColor('rgb(255, 255, 255)')
 - useColor('rgb(255, 255,)')


### PR DESCRIPTION
- Before : `// Argument of type '"#00ffzaz"' is not assignable to parameter
of type '...'.ts(2345)`
- After : `// Argument of type '"#00ffzz"' is not assignable to parameter
of type '...'.ts(2345)`

Change the wrong typo.