### PR TITLE
ci: replace Codecov with local coverage badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, v2-rewrite]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -34,6 +34,15 @@ jobs:
         
       - name: Size Limit
         run: pnpm size-limit
+
+      - name: Generate Coverage Badges
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: jpb06/coverage-badges-action@latest
+        with:
+          branches: main
+          badges-icon: vitest
+          coverage-summary-path: ./coverage/coverage-summary.json
+          commit-message: 'ci: update coverage badges'
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
     <img src="https://img.shields.io/bundlephobia/minzip/use-color?style=flat-square&color=FE69B5&labelColor=000&label=minzipped" alt="Bundle size" />
   </a>
   <img src="https://img.shields.io/badge/typescript-5.7+-blue?style=flat-square&color=FE69B5&labelColor=000" alt="TypeScript" />
-  <a href="https://codecov.io/gh/junhoyeo/use-color">
-    <img src="https://img.shields.io/codecov/c/github/junhoyeo/use-color?style=flat-square&color=FE69B5&labelColor=000" alt="Coverage" />
-  </a>
+<img src="./badges/coverage-total.svg" alt="Coverage" />
 </p>
 
 ---

--- a/badges/coverage-total.svg
+++ b/badges/coverage-total.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="110" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="a">
+    <rect width="110" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#a)">
+    <rect width="61" height="20" fill="#555"/>
+    <rect x="61" width="49" height="20" fill="#4c1"/>
+    <rect width="110" height="20" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="30.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="30.5" y="14">coverage</text>
+    <text x="84.5" y="15" fill="#010101" fill-opacity=".3">98%</text>
+    <text x="84.5" y="14">98%</text>
+  </g>
+</svg>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-coverage:
-  status:
-    project: no
-    patch: no

--- a/src/__tests__/property.test.ts
+++ b/src/__tests__/property.test.ts
@@ -488,7 +488,7 @@ describe('Property: Error Handling', () => {
   it('tryParseHex returns error for invalid strings', () => {
     fc.assert(
       fc.property(
-        fc.string().filter((s) => !s.match(/^#[0-9a-fA-F]{3,8}$/)),
+        fc.string().filter((s) => !s.match(/^#?[0-9a-fA-F]{3,8}$/)),
         (invalidStr) => {
           const result = tryParseHex(invalidStr);
           expect(result.ok).toBe(false);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'json-summary', 'html'],
       exclude: [
         // Barrel files (just re-exports, no logic to test)
         '**/index.ts',


### PR DESCRIPTION
## Summary

- Remove external Codecov integration and replace with local SVG badge generation
- Uses `jpb06/coverage-badges-action` to generate coverage badges on main branch push
- Update `vitest.config.ts` to include `json-summary` reporter for badge generation
- Fix flaky property test with regex pattern issue

## Changes

- Remove `codecov.yml`
- Update `vitest.config.ts` to generate `json-summary`
- Update `.github/workflows/ci.yml` to generate badges on main push
- Update `README.md` to reference local badge
- Fix property test regex pattern

## Why

Codecov is an external dependency that requires account setup and can have availability issues. Local badge generation is simpler, more reliable, and keeps everything self-contained.