### PR TITLE
fix: support percentage values for OKLCH chroma (C) component

### DIFF
--- a/packages/use-color/src/parse/__tests__/oklch.test.ts
+++ b/packages/use-color/src/parse/__tests__/oklch.test.ts
@@ -37,6 +37,74 @@ describe("parseOklch", () => {
 		});
 	});
 
+	describe("percentage chroma", () => {
+		it("parses oklch(0.96 2% 259) - chroma as percentage", () => {
+			const result = parseOklch("oklch(0.96 2% 259)");
+			expect(result.c).toBeCloseTo(0.008, 5);
+			expect(result).toEqual(expect.objectContaining({ l: 0.96, h: 259, a: 1 }));
+		});
+
+		it("parses oklch(0.5 50% 180) - 50% chroma = 0.2", () => {
+			const result = parseOklch("oklch(0.5 50% 180)");
+			expect(result.c).toBeCloseTo(0.2, 5);
+			expect(result).toEqual(expect.objectContaining({ l: 0.5, h: 180, a: 1 }));
+		});
+
+		it("parses oklch(0.5 100% 180) - 100% chroma = 0.4", () => {
+			const result = parseOklch("oklch(0.5 100% 180)");
+			expect(result.c).toBeCloseTo(0.4, 5);
+			expect(result).toEqual(expect.objectContaining({ l: 0.5, h: 180, a: 1 }));
+		});
+
+		it("parses oklch(0.5 0% 180) - 0% chroma = 0", () => {
+			const result = parseOklch("oklch(0.5 0% 180)");
+			expect(result.c).toBeCloseTo(0, 5);
+			expect(result).toEqual(expect.objectContaining({ l: 0.5, h: 180, a: 1 }));
+		});
+	});
+
+	describe("percentage lightness and chroma combined", () => {
+		it("parses oklch(96% 2% 259) - both L and C as percentages", () => {
+			const result = parseOklch("oklch(96% 2% 259)");
+			expect(result.l).toBeCloseTo(0.96, 5);
+			expect(result.c).toBeCloseTo(0.008, 5);
+			expect(result.h).toBe(259);
+			expect(result.a).toBe(1);
+		});
+
+		it("parses oklch(50% 50% 180) - both L and C at 50%", () => {
+			const result = parseOklch("oklch(50% 50% 180)");
+			expect(result.l).toBeCloseTo(0.5, 5);
+			expect(result.c).toBeCloseTo(0.2, 5);
+			expect(result.h).toBe(180);
+			expect(result.a).toBe(1);
+		});
+
+		it("parses oklch(100% 100% 0) - max percentages", () => {
+			const result = parseOklch("oklch(100% 100% 0)");
+			expect(result.l).toBeCloseTo(1, 5);
+			expect(result.c).toBeCloseTo(0.4, 5);
+			expect(result.h).toBe(0);
+			expect(result.a).toBe(1);
+		});
+
+		it("parses oklch(96% 2% 259 / 0.5) - percentages with alpha", () => {
+			const result = parseOklch("oklch(96% 2% 259 / 0.5)");
+			expect(result.l).toBeCloseTo(0.96, 5);
+			expect(result.c).toBeCloseTo(0.008, 5);
+			expect(result.h).toBe(259);
+			expect(result.a).toBe(0.5);
+		});
+
+		it("parses oklch(96% 2% 259 / 80%) - all percentages including alpha", () => {
+			const result = parseOklch("oklch(96% 2% 259 / 80%)");
+			expect(result.l).toBeCloseTo(0.96, 5);
+			expect(result.c).toBeCloseTo(0.008, 5);
+			expect(result.h).toBe(259);
+			expect(result.a).toBeCloseTo(0.8, 5);
+		});
+	});
+
 	describe("with alpha", () => {
 		it("parses oklch(0.5 0.2 180 / 0.5)", () => {
 			const result = parseOklch("oklch(0.5 0.2 180 / 0.5)");

--- a/packages/use-color/src/parse/oklch.ts
+++ b/packages/use-color/src/parse/oklch.ts
@@ -2,8 +2,9 @@ import { ColorErrorCode, ColorParseError } from "../errors.js";
 import type { OKLCH } from "../types/color.js";
 import { err, ok, type Result } from "../types/Result.js";
 
-/** Matches: oklch(L C H) or oklch(L C H / A) where L and A can be percentages */
-const OKLCH_REGEX = /^oklch\(\s*([0-9.]+%?)\s+([0-9.]+)\s+([0-9.]+)\s*(?:\/\s*([0-9.]+%?))?\s*\)$/i;
+/** Matches: oklch(L C H) or oklch(L C H / A) where L, C, and A can be percentages */
+const OKLCH_REGEX =
+	/^oklch\(\s*([0-9.]+%?)\s+([0-9.]+%?)\s+([0-9.]+)\s*(?:\/\s*([0-9.]+%?))?\s*\)$/i;
 
 function parsePercentageOrNumber(value: string, scale = 1): number {
 	if (value.endsWith("%")) {
@@ -64,7 +65,7 @@ export function tryParseOklch(str: string): Result<OKLCH, ColorParseError> {
 	const [, lStr, cStr, hStr, aStr] = match;
 
 	const l = parsePercentageOrNumber(lStr!, 1);
-	const c = parseFloat(cStr!);
+	const c = parsePercentageOrNumber(cStr!, 0.4);
 	const h = parseFloat(hStr!);
 	const a = aStr !== undefined ? parsePercentageOrNumber(aStr, 1) : 1;
 

--- a/packages/use-color/src/types/Oklch.ts
+++ b/packages/use-color/src/types/Oklch.ts
@@ -41,7 +41,7 @@ type SlashSep = `${OptSpace}/${OptSpace}`;
  * Format: oklch(L C H) where L can be number or percentage.
  * @internal
  */
-type OklchNoAlphaPattern = `oklch(${NumberOrPercent} ${NumberString} ${NumberString})`;
+type OklchNoAlphaPattern = `oklch(${NumberOrPercent} ${NumberOrPercent} ${NumberString})`;
 
 /**
  * Pattern for OKLCH color with alpha channel.
@@ -49,7 +49,7 @@ type OklchNoAlphaPattern = `oklch(${NumberOrPercent} ${NumberString} ${NumberStr
  * @internal
  */
 type OklchAlphaPattern =
-	`oklch(${NumberOrPercent} ${NumberString} ${NumberString}${SlashSep}${NumberOrPercent})`;
+	`oklch(${NumberOrPercent} ${NumberOrPercent} ${NumberString}${SlashSep}${NumberOrPercent})`;
 
 /**
  * Validates an OKLCH color string without alpha channel.

--- a/packages/use-color/src/types/__tests__/oklch.test-d.ts
+++ b/packages/use-color/src/types/__tests__/oklch.test-d.ts
@@ -42,6 +42,13 @@ describe("Oklch types", () => {
 		expectTypeOf<OklchString<"oklch(0.5 0.4 180)">>().toEqualTypeOf<"oklch(0.5 0.4 180)">();
 	});
 
+	it("OklchString validates percentage chroma values", () => {
+		expectTypeOf<OklchString<"oklch(0.5 50% 180)">>().toEqualTypeOf<"oklch(0.5 50% 180)">();
+		expectTypeOf<OklchString<"oklch(0.5 0% 180)">>().toEqualTypeOf<"oklch(0.5 0% 180)">();
+		expectTypeOf<OklchString<"oklch(0.5 100% 180)">>().toEqualTypeOf<"oklch(0.5 100% 180)">();
+		expectTypeOf<OklchString<"oklch(96% 2% 259)">>().toEqualTypeOf<"oklch(96% 2% 259)">();
+	});
+
 	it("OklchString rejects comma-separated format", () => {
 		expectTypeOf<OklchString<"oklch(0.5, 0.2, 180)">>().toEqualTypeOf<never>();
 		expectTypeOf<OklchString<"oklch(50%, 0.2, 180)">>().toEqualTypeOf<never>();
@@ -98,6 +105,15 @@ describe("Oklch types", () => {
 		>().toEqualTypeOf<"oklch(50% 0.2 180 / 80%)">();
 	});
 
+	it("OklchAlphaString validates percentage chroma with alpha", () => {
+		expectTypeOf<
+			OklchAlphaString<"oklch(0.96 2% 259 / 0.5)">
+		>().toEqualTypeOf<"oklch(0.96 2% 259 / 0.5)">();
+		expectTypeOf<
+			OklchAlphaString<"oklch(96% 2% 259 / 80%)">
+		>().toEqualTypeOf<"oklch(96% 2% 259 / 80%)">();
+	});
+
 	it("OklchAlphaString validates flexible whitespace around slash", () => {
 		expectTypeOf<
 			OklchAlphaString<"oklch(0.5 0.2 180/0.5)">
@@ -140,6 +156,14 @@ describe("Oklch types", () => {
 		expectTypeOf<
 			OklchInputString<"oklch(1 0.4 360 / 1)">
 		>().toEqualTypeOf<"oklch(1 0.4 360 / 1)">();
+	});
+
+	it("OklchInputString accepts percentage chroma", () => {
+		expectTypeOf<OklchInputString<"oklch(0.5 50% 180)">>().toEqualTypeOf<"oklch(0.5 50% 180)">();
+		expectTypeOf<OklchInputString<"oklch(96% 2% 259)">>().toEqualTypeOf<"oklch(96% 2% 259)">();
+		expectTypeOf<
+			OklchInputString<"oklch(96% 2% 259 / 0.5)">
+		>().toEqualTypeOf<"oklch(96% 2% 259 / 0.5)">();
 	});
 
 	it("OklchInputString rejects invalid formats", () => {


### PR DESCRIPTION
## Summary

- **Bug**: `oklch(96% 2% 259)` (percentage chroma) was rejected as invalid because the parser only allowed `%` on lightness (L) and alpha (A), not chroma (C)
- **Fix**: Updated regex, parsing logic (scale 0.4 for C%), and TypeScript compile-time type patterns to accept percentage chroma per [CSS Color Level 4 spec](https://www.w3.org/TR/css-color-4/#funcdef-oklch)
- **Tests**: Added 9 runtime tests and 3 type-level test groups covering percentage chroma, mixed L%+C%, and C% with alpha

## CSS Color Level 4 Reference

| Component | Number range | Percentage range | Mapping |
|-----------|-------------|-----------------|---------|
| L (lightness) | 0–1 | 0%–100% | 100% → 1 |
| **C (chroma)** | **0–0.4** | **0%–100%** | **100% → 0.4** |
| H (hue) | 0–360 | N/A (degrees) | — |

## Changes

| File | Change |
|------|--------|
| `parse/oklch.ts` | Regex: `([0-9.]+)` → `([0-9.]+%?)` for C; parsing: `parseFloat` → `parsePercentageOrNumber(cStr, 0.4)` |
| `types/Oklch.ts` | `OklchNoAlphaPattern` and `OklchAlphaPattern`: `NumberString` → `NumberOrPercent` for C position |
| `parse/__tests__/oklch.test.ts` | 9 new tests: percentage chroma, mixed L%+C%, C% with alpha |
| `types/__tests__/oklch.test-d.ts` | 3 new type-level test groups for percentage chroma validation |

## Verification

All **1862 tests pass** across 53 test files, zero type errors.