### PR TITLE
fix(errors): remove global ErrorConstructor augmentation breaking dts build

### DIFF
--- a/packages/use-color/src/errors.ts
+++ b/packages/use-color/src/errors.ts
@@ -17,10 +17,17 @@
  * ```
  */
 
-// V8-specific extension for better stack traces
-declare global {
-	interface ErrorConstructor {
-		captureStackTrace?(targetObject: object, constructorOpt?: Function): void;
+// V8-specific extension for better stack traces. Typed structurally instead of
+// augmenting ErrorConstructor globally: a global augmentation conflicts with
+// @types/node's required signature (TS2386) in consuming projects.
+type V8ErrorConstructor = {
+	captureStackTrace?(targetObject: object, constructorOpt?: unknown): void;
+};
+
+function captureStackTrace(target: Error, ctor: unknown): void {
+	const v8 = Error as V8ErrorConstructor;
+	if (typeof v8.captureStackTrace === "function") {
+		v8.captureStackTrace(target, ctor);
 	}
 }
 
@@ -104,9 +111,7 @@ export class ColorParseError extends Error {
 		this.code = code;
 
 		// Maintains proper stack trace in V8 environments (Node.js, Chrome)
-		if (typeof Error.captureStackTrace === "function") {
-			Error.captureStackTrace(this, ColorParseError);
-		}
+		captureStackTrace(this, ColorParseError);
 	}
 }
 
@@ -165,8 +170,6 @@ export class ColorOutOfGamutError extends ColorParseError {
 		this.targetGamut = targetGamut;
 
 		// Maintains proper stack trace in V8 environments (Node.js, Chrome)
-		if (typeof Error.captureStackTrace === "function") {
-			Error.captureStackTrace(this, ColorOutOfGamutError);
-		}
+		captureStackTrace(this, ColorOutOfGamutError);
 	}
 }


### PR DESCRIPTION
## P0 — ship blocker (audit item 0.1)

The `declare global { interface ErrorConstructor { captureStackTrace?(...) } }` augmentation in `src/errors.ts` conflicts with @types/node's required `captureStackTrace` signature → **TS2386**, which broke:

- `pnpm typecheck` (`tsc --noEmit` failed)
- `pnpm test` (all 1862 tests passed, but the run exited nonzero from the typecheck error)
- `pnpm build` dts step → **the published package shipped zero `.d.ts` files**, gutting the type-safety pitch

### Fix
Deleted the global augmentation; added a local `captureStackTrace()` helper that structurally casts `Error` at the use site. No global types are modified, so it compiles with or without @types/node. Also clears the biome `noBannedTypes` warning on the same line.

### Verification
- `pnpm typecheck` ✅
- `pnpm build` ✅ — `dist/*.d.ts` / `*.d.cts` now emitted
- `pnpm test` ✅ — 1862/1862, exit code 0

---
Part of the 2026-07-16 ultracode audit fix series (PR 1/10). Merge first — everything downstream stacks on this.