### PR TITLE
fix(ops,a11y): ensureContrast validity, APCA 2.4 curve, achromatic hue mixing

### DIFF
--- a/packages/use-color/src/a11y/__tests__/adjust.test.ts
+++ b/packages/use-color/src/a11y/__tests__/adjust.test.ts
@@ -144,30 +144,135 @@ describe("ensureContrast", () => {
 			expect(ratio).toBeGreaterThanOrEqual(4.5);
 		});
 
-		it("returns secondary result when it has better contrast (line 262 false branch)", () => {
-			// Force preferLighten on a light background where darkening is better
-			// Primary (lighten) gives worse contrast, secondary (darken) is better
+		it("falls back to black or white when preferLighten=true and target is unreachable", () => {
+			// minRatio=21 exceeds the maximum possible contrast ratio (21:1 is the
+			// theoretical max, only achieved by pure black on pure white), so
+			// neither lightness-adjustment direction can reach it. This now
+			// exercises the explicit black/white fallback rather than falling
+			// back to a (previously dead) "better of the two directions" branch.
 			const darkFg = { r: 100, g: 100, b: 100, a: 1 };
 			const lightBg = { r: 220, g: 220, b: 220, a: 1 };
 
 			const result = ensureContrast(darkFg, lightBg, 21, { preferLighten: true });
 
 			expect(result.space).toBe("rgb");
+			// Against a light background, black gives the higher contrast.
+			expect(result.r).toBe(0);
+			expect(result.g).toBe(0);
+			expect(result.b).toBe(0);
 			const finalRatio = contrast(result, lightBg);
 			expect(finalRatio).toBeGreaterThan(1);
 		});
 
-		it("returns primary result when it has better contrast (line 262 true branch)", () => {
-			// Use preferLighten=false on light bg - primary (darken) is correct
-			// but target is impossible, so both directions fail
+		it("falls back to black or white when preferLighten=false and target is unreachable", () => {
 			const midFg = { r: 150, g: 150, b: 150, a: 1 };
 			const lightBg = { r: 200, g: 200, b: 200, a: 1 };
 
 			const result = ensureContrast(midFg, lightBg, 21, { preferLighten: false });
 
 			expect(result.space).toBe("rgb");
+			expect(result.r).toBe(0);
+			expect(result.g).toBe(0);
+			expect(result.b).toBe(0);
 			const finalRatio = contrast(result, lightBg);
 			expect(finalRatio).toBeGreaterThan(1);
+		});
+
+		it("falls back to white when it gives higher contrast than black against a dark bg", () => {
+			// Unreachable target (21) against a dark background: white should
+			// win the black-vs-white fallback comparison.
+			const midFg = { r: 60, g: 60, b: 60, a: 1 };
+			const darkBg = { r: 30, g: 30, b: 30, a: 1 };
+
+			const result = ensureContrast(midFg, darkBg, 21);
+
+			expect(result.r).toBe(255);
+			expect(result.g).toBe(255);
+			expect(result.b).toBe(255);
+		});
+
+		it("preserves original alpha in the black/white fallback", () => {
+			const midFg = { r: 150, g: 150, b: 150, a: 0.4 };
+			const lightBg = { r: 200, g: 200, b: 200, a: 1 };
+
+			const result = ensureContrast(midFg, lightBg, 21);
+			expect(result.a).toBe(0.4);
+		});
+	});
+
+	describe("convergence at WCAG boundaries (1.6 fix)", () => {
+		it("converges to >= AA (4.5) for a near-threshold gray pair", () => {
+			// Chosen so the input is just below the AA threshold, forcing the
+			// binary search to actually adjust lightness to converge.
+			const nearAaFg = { r: 160, g: 160, b: 160, a: 1 };
+			const result = ensureContrast(nearAaFg, white, WCAG_THRESHOLDS.AA);
+			const ratio = contrast(result, white);
+			expect(ratio).toBeGreaterThanOrEqual(WCAG_THRESHOLDS.AA);
+		});
+
+		it("converges to >= AAA (7) for a near-threshold gray pair", () => {
+			const nearAaaFg = { r: 130, g: 130, b: 130, a: 1 };
+			const result = ensureContrast(nearAaaFg, white, WCAG_THRESHOLDS.AAA);
+			const ratio = contrast(result, white);
+			expect(ratio).toBeGreaterThanOrEqual(WCAG_THRESHOLDS.AAA);
+		});
+
+		it("converges to >= AA for near-threshold colored input on a dark background", () => {
+			const nearThresholdFg = { r: 90, g: 95, b: 100, a: 1 };
+			const darkBg = { r: 20, g: 20, b: 25, a: 1 };
+			const result = ensureContrast(nearThresholdFg, darkBg, WCAG_THRESHOLDS.AA);
+			const ratio = contrast(result, darkBg);
+			expect(ratio).toBeGreaterThanOrEqual(WCAG_THRESHOLDS.AA);
+		});
+
+		it("converges to >= AAA for near-threshold colored input against mid-tone bg", () => {
+			const nearThresholdFg = { r: 140, g: 130, b: 150, a: 1 };
+			const midBg = { r: 210, g: 205, b: 215, a: 1 };
+			const result = ensureContrast(nearThresholdFg, midBg, WCAG_THRESHOLDS.AAA);
+			const ratio = contrast(result, midBg);
+			expect(ratio).toBeGreaterThanOrEqual(WCAG_THRESHOLDS.AAA);
+		});
+
+		it("only black or white can satisfy an extreme target against a mid-gray bg", () => {
+			// Against 50%-gray, no in-gamut chroma-preserving lightness
+			// adjustment can reach a 15:1 ratio (max ~ black-or-white vs mid
+			// gray), so the result must be exactly black or white.
+			const fg = { r: 140, g: 140, b: 140, a: 1 };
+			const midBg = { r: 128, g: 128, b: 128, a: 1 };
+			const result = ensureContrast(fg, midBg, 15);
+			const isBlack = result.r === 0 && result.g === 0 && result.b === 0;
+			const isWhite = result.r === 255 && result.g === 255 && result.b === 255;
+			expect(isBlack || isWhite).toBe(true);
+			expect(contrast(result, midBg)).toBeGreaterThan(contrast(fg, midBg));
+		});
+
+		it("always returns channels within [0, 255], across a sweep of inputs and targets", () => {
+			const fgs = [
+				{ r: 0, g: 0, b: 0, a: 1 },
+				{ r: 255, g: 255, b: 255, a: 1 },
+				{ r: 128, g: 64, b: 200, a: 1 },
+				{ r: 200, g: 100, b: 50, a: 1 },
+				{ r: 10, g: 10, b: 10, a: 1 },
+			];
+			const bgs = [white, black, gray, { r: 30, g: 30, b: 30, a: 1 }];
+			const ratios = [1, 2, 4.5, 7, 15, 21];
+
+			for (const fg of fgs) {
+				for (const bg of bgs) {
+					for (const ratio of ratios) {
+						const result = ensureContrast(fg, bg, ratio);
+						expect(result.r).toBeGreaterThanOrEqual(0);
+						expect(result.r).toBeLessThanOrEqual(255);
+						expect(result.g).toBeGreaterThanOrEqual(0);
+						expect(result.g).toBeLessThanOrEqual(255);
+						expect(result.b).toBeGreaterThanOrEqual(0);
+						expect(result.b).toBeLessThanOrEqual(255);
+						expect(Number.isNaN(result.r)).toBe(false);
+						expect(Number.isNaN(result.g)).toBe(false);
+						expect(Number.isNaN(result.b)).toBe(false);
+					}
+				}
+			}
 		});
 	});
 

--- a/packages/use-color/src/a11y/__tests__/apca.test.ts
+++ b/packages/use-color/src/a11y/__tests__/apca.test.ts
@@ -107,6 +107,48 @@ describe("apcaContrast", () => {
 	});
 });
 
+describe("APCA reference values (0.0.98G power-curve transfer function)", () => {
+	// Canonical Lc values from the SAPC-APCA 0.0.98G reference implementation.
+	// These validate that the luminance transfer function uses the simple
+	// 2.4 power curve `(c/255)^2.4`, not the piecewise sRGB curve.
+	it("#888888 text on #ffffff bg ~= 63.06", () => {
+		const lc = apcaContrast(
+			{ r: 0x88, g: 0x88, b: 0x88, a: 1 },
+			{ r: 0xff, g: 0xff, b: 0xff, a: 1 },
+		);
+		expect(lc).toBeCloseTo(63.06, 1);
+	});
+
+	it("#ffffff text on #888888 bg ~= -68.54", () => {
+		const lc = apcaContrast(
+			{ r: 0xff, g: 0xff, b: 0xff, a: 1 },
+			{ r: 0x88, g: 0x88, b: 0x88, a: 1 },
+		);
+		expect(lc).toBeCloseTo(-68.54, 1);
+	});
+
+	it("#000000 text on #aaaaaa bg ~= 58.14", () => {
+		const lc = apcaContrast({ r: 0, g: 0, b: 0, a: 1 }, { r: 0xaa, g: 0xaa, b: 0xaa, a: 1 });
+		expect(lc).toBeCloseTo(58.14, 1);
+	});
+
+	it("#112233 text on #ddeeff bg ~= 91.66", () => {
+		const lc = apcaContrast(
+			{ r: 0x11, g: 0x22, b: 0x33, a: 1 },
+			{ r: 0xdd, g: 0xee, b: 0xff, a: 1 },
+		);
+		expect(lc).toBeCloseTo(91.66, 1);
+	});
+
+	it("#223344 text on #112233 bg is below the low-clip threshold, clips to 0", () => {
+		const lc = apcaContrast(
+			{ r: 0x22, g: 0x33, b: 0x44, a: 1 },
+			{ r: 0x11, g: 0x22, b: 0x33, a: 1 },
+		);
+		expect(lc).toBe(0);
+	});
+});
+
 describe("APCA_THRESHOLDS", () => {
 	it("has correct recommended values", () => {
 		expect(APCA_THRESHOLDS.BODY_TEXT).toBe(75);

--- a/packages/use-color/src/a11y/adjust.ts
+++ b/packages/use-color/src/a11y/adjust.ts
@@ -80,6 +80,17 @@ function toRgba(color: LuminanceInput): RGBA {
  * Adjusts the lightness of a color to achieve a target contrast ratio.
  * Uses binary search on OKLCH lightness for perceptually uniform adjustment.
  *
+ * Every candidate is produced via {@link oklchToRgb}, which gamut-maps
+ * through {@link clampToGamut} before conversion, so every RGBA this
+ * function considers (and returns) is already guaranteed to have channels
+ * in [0, 255] - contrast is always measured on the actual color that will
+ * be returned, never on an out-of-gamut candidate.
+ *
+ * If the target ratio is never reached within `maxIterations`, this
+ * returns the best-effort candidate that came closest to (without
+ * exceeding into) the search, falling back to the last-tested candidate
+ * rather than the original (still-failing) input color.
+ *
  * @param fgOklch - Foreground color in OKLCH
  * @param bgRgba - Background color in RGBA
  * @param targetRatio - Target contrast ratio
@@ -98,9 +109,16 @@ function adjustLightness(
 ): RGBA {
 	let low = lighten ? fgOklch.l : 0;
 	let high = lighten ? 1 : fgOklch.l;
-	let bestRgba: RGBA = oklchToRgb(fgOklch);
-	let bestRatio = contrast(bestRgba, bgRgba);
-	let bestDiff = Math.abs(bestRatio - targetRatio);
+
+	// Only set once the target ratio has actually been met; never falls back
+	// to the original (failing) color.
+	let bestRgba: RGBA | null = null;
+	let bestDiff = Number.POSITIVE_INFINITY;
+
+	// Tracks the most recently tested candidate so that, if the target is
+	// never reached, we can still return the closest attempt instead of the
+	// original failing color.
+	let lastRgba: RGBA = oklchToRgb(fgOklch);
 
 	for (let i = 0; i < maxIterations; i++) {
 		const mid = (low + high) / 2;
@@ -109,10 +127,11 @@ function adjustLightness(
 		const testRatio = contrast(testRgba, bgRgba);
 		const diff = Math.abs(testRatio - targetRatio);
 
+		lastRgba = testRgba;
+
 		// Update best if this is closer to target and meets minimum
 		if (testRatio >= targetRatio && diff < bestDiff) {
 			bestRgba = testRgba;
-			bestRatio = testRatio;
 			bestDiff = diff;
 		}
 
@@ -139,7 +158,7 @@ function adjustLightness(
 		}
 	}
 
-	return bestRgba;
+	return bestRgba ?? lastRgba;
 }
 
 /**
@@ -258,14 +277,16 @@ export function ensureContrast(
 		};
 	}
 
-	// Return the one with better contrast
-	/* istanbul ignore next -- @preserve unreachable: both directions return same color when target impossible */
-	const result = primaryRatio >= secondaryRatio ? primaryResult : secondaryResult;
-	return {
-		space: "rgb",
-		r: result.r,
-		g: result.g,
-		b: result.b,
-		a: result.a,
-	};
+	// Neither direction reached minRatio within gamut: the target is
+	// unreachable by adjusting lightness alone. Fall back to whichever of
+	// pure black or pure white gives higher contrast against the
+	// background - these are the extremes of the lightness range, so if
+	// they can't satisfy minRatio, nothing in gamut can.
+	const black: RGBA = { r: 0, g: 0, b: 0, a: fgRgba.a };
+	const white: RGBA = { r: 255, g: 255, b: 255, a: fgRgba.a };
+	const blackRatio = contrast(black, bgRgba);
+	const whiteRatio = contrast(white, bgRgba);
+	const fallback = blackRatio >= whiteRatio ? black : white;
+
+	return { space: "rgb", r: fallback.r, g: fallback.g, b: fallback.b, a: fallback.a };
 }

--- a/packages/use-color/src/a11y/apca.ts
+++ b/packages/use-color/src/a11y/apca.ts
@@ -46,7 +46,6 @@
  */
 
 import { convert } from "../convert/index.js";
-import { srgbToLinear } from "../convert/linear.js";
 import type { AnyColor } from "../types/ColorObject.js";
 import type { RGBA } from "../types/color.js";
 
@@ -104,13 +103,25 @@ function toRgba(color: APCAInput): RGBA {
 }
 
 /**
+ * APCA transfer function exponent.
+ * SAPC 0.0.98G specifies a simple 2.4 power curve for gamma expansion,
+ * NOT the piecewise sRGB transfer function (linear segment + power curve)
+ * used elsewhere in this library (e.g. {@link srgbToLinear}). Using the
+ * piecewise curve here deviates from the reference implementation by up
+ * to ~3 Lc.
+ */
+const APCA_MAIN_TRC = 2.4;
+
+/**
  * Calculates APCA Y (luminance) from RGBA.
- * This is similar to but not identical to WCAG relative luminance.
+ * This is similar to but not identical to WCAG relative luminance:
+ * APCA uses a plain `(c/255)^2.4` power curve for gamma expansion,
+ * while WCAG relative luminance uses the piecewise sRGB transfer function.
  */
 function calcAPCALuminance(rgba: RGBA): number {
-	const r = srgbToLinear(rgba.r);
-	const g = srgbToLinear(rgba.g);
-	const b = srgbToLinear(rgba.b);
+	const r = (rgba.r / 255) ** APCA_MAIN_TRC;
+	const g = (rgba.g / 255) ** APCA_MAIN_TRC;
+	const b = (rgba.b / 255) ** APCA_MAIN_TRC;
 
 	return APCA_CONSTANTS.sRco * r + APCA_CONSTANTS.sGco * g + APCA_CONSTANTS.sBco * b;
 }

--- a/packages/use-color/src/ops/__tests__/mix.test.ts
+++ b/packages/use-color/src/ops/__tests__/mix.test.ts
@@ -243,7 +243,33 @@ describe("mixColors", () => {
 		});
 
 		it("throws when a weight is NaN", () => {
-			expect(() => mixColors([red, blue], [1, Number.NaN])).toThrow("must not contain NaN");
+			expect(() => mixColors([red, blue], [1, Number.NaN])).toThrow("must be finite");
+		});
+
+		it("throws when a weight is Infinity", () => {
+			expect(() => mixColors([red, blue], [Number.POSITIVE_INFINITY, 1])).toThrow("must be finite");
+		});
+
+		it("throws when finite weights overflow when summed", () => {
+			expect(() => mixColors([red, blue], [Number.MAX_VALUE, Number.MAX_VALUE])).toThrow(
+				"overflows to Infinity",
+			);
+		});
+
+		it("ignores the arbitrary stored hue of achromatic entries (CSS Color 4 §12.3)", () => {
+			// Gray carries h=180 but c=0 — hue-less; the average must keep h≈0
+			// from the chromatic entry instead of drifting toward 90.
+			const chromatic = { space: "oklch", l: 0.6, c: 0.2, h: 0, a: 1 } as const;
+			const gray = { space: "oklch", l: 0.8, c: 0, h: 180, a: 1 } as const;
+			const result = mixColors([chromatic, gray]) as OklchColor;
+			expect(Math.min(result.h, 360 - result.h)).toBeLessThan(1);
+		});
+
+		it("returns hue 0 when every entry is achromatic", () => {
+			const g1 = { space: "oklch", l: 0.3, c: 0, h: 45, a: 1 } as const;
+			const g2 = { space: "oklch", l: 0.7, c: 0, h: 270, a: 1 } as const;
+			const result = mixColors([g1, g2]) as OklchColor;
+			expect(result.h).toBe(0);
 		});
 
 		it("does not throw for valid weights, and never produces NaN channels", () => {

--- a/packages/use-color/src/ops/__tests__/mix.test.ts
+++ b/packages/use-color/src/ops/__tests__/mix.test.ts
@@ -99,6 +99,47 @@ describe("mix", () => {
 			expect(result.c).toBe(0);
 		});
 	});
+
+	describe("hue interpolation with achromatic colors (1.8 fix)", () => {
+		it("mix(red, white) keeps hue within ~1deg of red's hue at any ratio", () => {
+			// Chroma kept modest (matches the c=0.15 convention used elsewhere in
+			// this file) so the mixed color stays in sRGB gamut - otherwise
+			// clampToGamut's chroma reduction can shift the hue slightly, which
+			// would be an artifact of gamut mapping, not of hue interpolation.
+			const red: OKLCH = { l: 0.6, c: 0.15, h: 29, a: 1 };
+			const white: OKLCH = { l: 1, c: 0, h: 0, a: 1 };
+			for (const ratio of [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1]) {
+				const result = mix(red, white, ratio) as OKLCH;
+				expect(Math.abs(result.h - red.h)).toBeLessThan(1);
+			}
+		});
+
+		it("mix(white, red) keeps hue within ~1deg of red's hue at any ratio", () => {
+			const red: OKLCH = { l: 0.6, c: 0.15, h: 29, a: 1 };
+			const white: OKLCH = { l: 1, c: 0, h: 0, a: 1 };
+			for (const ratio of [0, 0.25, 0.5, 0.75, 1]) {
+				const result = mix(white, red, ratio) as OKLCH;
+				expect(Math.abs(result.h - red.h)).toBeLessThan(1);
+			}
+		});
+
+		it("mix(gray, gray) stays achromatic", () => {
+			const gray1: OKLCH = { l: 0.3, c: 0, h: 123, a: 1 };
+			const gray2: OKLCH = { l: 0.7, c: 0, h: 77, a: 1 };
+			const result = mix(gray1, gray2, 0.5) as OKLCH;
+			expect(result.c).toBe(0);
+			expect(result.h).toBe(0);
+		});
+
+		it("mix(chromatic, gray) uses the chromatic side's hue throughout", () => {
+			const blue: OKLCH = { l: 0.5, c: 0.2, h: 260, a: 1 };
+			const gray: OKLCH = { l: 0.5, c: 0, h: 0, a: 1 };
+			for (const ratio of [0.1, 0.5, 0.9]) {
+				const result = mix(blue, gray, ratio) as OKLCH;
+				expect(result.h).toBeCloseTo(260, 5);
+			}
+		});
+	});
 });
 
 describe("mixColors", () => {
@@ -174,6 +215,43 @@ describe("mixColors", () => {
 			const a0: OklchColor = { space: "oklch", l: 0.5, c: 0.1, h: 30, a: 0 };
 			const result = mixColors([a1, a0]) as OklchColor;
 			expect(result.a).toBeCloseTo(0.5, 5);
+		});
+	});
+
+	describe("weight validation (1.9 fix)", () => {
+		const red: OklchColor = { space: "oklch", l: 0.6, c: 0.2, h: 30, a: 1 };
+		const blue: OklchColor = { space: "oklch", l: 0.4, c: 0.2, h: 260, a: 1 };
+
+		it("throws when weights.length does not match colors.length (too few)", () => {
+			expect(() => mixColors([red, blue], [1])).toThrow(
+				/weights\.length.*must match colors\.length/,
+			);
+		});
+
+		it("throws when weights.length does not match colors.length (too many)", () => {
+			expect(() => mixColors([red, blue], [1, 1, 1])).toThrow(
+				/weights\.length.*must match colors\.length/,
+			);
+		});
+
+		it("throws when weights sum to zero", () => {
+			expect(() => mixColors([red, blue], [0, 0])).toThrow("must not sum to zero");
+		});
+
+		it("throws when a weight is negative", () => {
+			expect(() => mixColors([red, blue], [1, -1])).toThrow("must not be negative");
+		});
+
+		it("throws when a weight is NaN", () => {
+			expect(() => mixColors([red, blue], [1, Number.NaN])).toThrow("must not contain NaN");
+		});
+
+		it("does not throw for valid weights, and never produces NaN channels", () => {
+			const result = mixColors([red, blue], [2, 1]) as OklchColor;
+			expect(Number.isNaN(result.l)).toBe(false);
+			expect(Number.isNaN(result.c)).toBe(false);
+			expect(Number.isNaN(result.h)).toBe(false);
+			expect(Number.isNaN(result.a)).toBe(false);
 		});
 	});
 });

--- a/packages/use-color/src/ops/mix.ts
+++ b/packages/use-color/src/ops/mix.ts
@@ -9,6 +9,13 @@ export type { ColorInput };
 
 export type MixSpace = "oklch" | "rgb";
 
+/**
+ * Chroma below this threshold is treated as achromatic ("hue-less") per
+ * CSS Color 4 hue interpolation rules: a hue paired with c ~= 0 carries no
+ * meaningful information, so it must not be interpolated as if it did.
+ */
+const HUE_EPSILON = 1e-4;
+
 function normalizeHue(hue: number): number {
 	const result = hue % 360;
 	return result < 0 ? result + 360 : result;
@@ -24,10 +31,37 @@ function interpolateHue(h1: number, h2: number, ratio: number): number {
 	return normalizeHue(h1 + diff * ratio);
 }
 
+/**
+ * Interpolates the hue component for OKLCH mixing, treating near-zero
+ * chroma as "none" (hue-less) per CSS Color 4 §12.3. White/gray/black
+ * carry a technically-defined but meaningless hue; naively interpolating
+ * toward it (e.g. mixing red with white) would drag the hue toward that
+ * arbitrary value. Instead:
+ * - If one side is hue-less, the other side's hue is used for the whole
+ *   interpolation (i.e. hue stays constant).
+ * - If both sides are hue-less, hue is irrelevant.
+ * - Otherwise, hue is interpolated normally via the shortest arc.
+ */
+function mixHue(a: OKLCH, b: OKLCH, ratio: number): number {
+	const aHueless = a.c < HUE_EPSILON;
+	const bHueless = b.c < HUE_EPSILON;
+
+	if (aHueless && bHueless) {
+		return 0;
+	}
+	if (aHueless) {
+		return normalizeHue(b.h);
+	}
+	if (bHueless) {
+		return normalizeHue(a.h);
+	}
+	return interpolateHue(a.h, b.h, ratio);
+}
+
 function mixInOklch(a: OKLCH, b: OKLCH, ratio: number): OKLCH {
 	const l = a.l + (b.l - a.l) * ratio;
 	const c = a.c + (b.c - a.c) * ratio;
-	const h = interpolateHue(a.h, b.h, ratio);
+	const h = mixHue(a, b, ratio);
 	const alpha = a.a + (b.a - a.a) * ratio;
 	return { l, c, h, a: alpha };
 }
@@ -76,6 +110,37 @@ export function mixColors(
 			"mixColors requires at least one color",
 		);
 	}
+
+	if (weights !== undefined) {
+		if (weights.length !== colors.length) {
+			throw new ColorParseError(
+				ColorErrorCode.INVALID_FORMAT,
+				`mixColors: weights.length (${weights.length}) must match colors.length (${colors.length})`,
+			);
+		}
+		for (const weight of weights) {
+			if (Number.isNaN(weight)) {
+				throw new ColorParseError(
+					ColorErrorCode.INVALID_FORMAT,
+					"mixColors: weights must not contain NaN",
+				);
+			}
+			if (weight < 0) {
+				throw new ColorParseError(
+					ColorErrorCode.INVALID_FORMAT,
+					"mixColors: weights must not be negative",
+				);
+			}
+		}
+		const weightSum = weights.reduce((sum, w) => sum + w, 0);
+		if (weightSum === 0) {
+			throw new ColorParseError(
+				ColorErrorCode.INVALID_FORMAT,
+				"mixColors: weights must not sum to zero",
+			);
+		}
+	}
+
 	if (colors.length === 1) {
 		const color = colors[0]!;
 		if (hasSpace(color)) {

--- a/packages/use-color/src/ops/mix.ts
+++ b/packages/use-color/src/ops/mix.ts
@@ -119,10 +119,10 @@ export function mixColors(
 			);
 		}
 		for (const weight of weights) {
-			if (Number.isNaN(weight)) {
+			if (!Number.isFinite(weight)) {
 				throw new ColorParseError(
 					ColorErrorCode.INVALID_FORMAT,
-					"mixColors: weights must not contain NaN",
+					"mixColors: weights must be finite numbers",
 				);
 			}
 			if (weight < 0) {
@@ -137,6 +137,15 @@ export function mixColors(
 			throw new ColorParseError(
 				ColorErrorCode.INVALID_FORMAT,
 				"mixColors: weights must not sum to zero",
+			);
+		}
+		// Individually-finite weights can still overflow when summed
+		// (e.g. [MAX_VALUE, MAX_VALUE]), which would zero every normalized
+		// weight via division by Infinity.
+		if (!Number.isFinite(weightSum)) {
+			throw new ColorParseError(
+				ColorErrorCode.INVALID_FORMAT,
+				"mixColors: weights sum overflows to Infinity",
 			);
 		}
 	}
@@ -162,7 +171,8 @@ export function mixColors(
 			c = 0,
 			a = 0;
 		let sinH = 0,
-			cosH = 0;
+			cosH = 0,
+			hueWeight = 0;
 
 		for (let i = 0; i < colors.length; i++) {
 			const oklch = toOklch(colors[i]!);
@@ -170,12 +180,18 @@ export function mixColors(
 			l += oklch.l * w;
 			c += oklch.c * w;
 			a += oklch.a * w;
-			const hRad = oklch.h * (Math.PI / 180);
-			sinH += Math.sin(hRad) * w;
-			cosH += Math.cos(hRad) * w;
+			// Achromatic entries (c ~= 0) are hue-less per CSS Color 4 §12.3:
+			// their stored hue is arbitrary and must not drag the circular
+			// average. Only hue-carrying entries contribute.
+			if (oklch.c >= HUE_EPSILON) {
+				const hRad = oklch.h * (Math.PI / 180);
+				sinH += Math.sin(hRad) * w;
+				cosH += Math.cos(hRad) * w;
+				hueWeight += w;
+			}
 		}
 
-		const h = normalizeHue(Math.atan2(sinH, cosH) * (180 / Math.PI));
+		const h = hueWeight > 0 ? normalizeHue(Math.atan2(sinH, cosH) * (180 / Math.PI)) : 0;
 		const result = clampToGamut({ l, c, h, a });
 		return { space: "oklch" as const, ...result };
 	}


### PR DESCRIPTION
## P1-B — ops + a11y (audit items 1.6–1.9)

> Stacked on #14 — diff shown against `fix/p1a-conversion-pipeline`.

1. **1.6 (CRITICAL)** `ensureContrast` returned invalid colors (r=367, g=-62), reported contrast it hadn't achieved (measured pre-clamp), and failed to converge near thresholds. Now: every candidate is gamut-clamped **before** measuring, contrast is measured on the color actually returned, and black/white fallback kicks in when the target is unreachable. Convergence tests added at AA/AAA boundaries. Verified: `ensureContrast(#777, #888, 4.5)` → `rgb(33,33,33)` with real contrast 4.542.
2. **1.7** APCA used piecewise sRGB linearization; 0.0.98G specifies the simple 2.4 power curve (Lc deviated up to ~3). Now matches published reference values: `#888` on `#fff` → **63.06** (ref 63.06), `#fff` on `#888` → **-68.54** (ref -68.54), `#000` on `#aaa` → 58.15 (ref 58.14).
3. **1.8** OKLCH mix interpolated toward the meaningless hue carried by white/gray/black. Now c < 1e-4 is treated as hue-less per CSS Color 4 §12.3 — `mix(red, white)` stays on the red hue line at every ratio.
4. **1.9** `mixColors` silently produced NaN channels on mismatched/zero/negative/NaN weights — now throws `ColorParseError` with a specific message per case.

### Verification
`pnpm typecheck && pnpm test && pnpm build && pnpm lint` ✅ — **1893/1893** (23 new tests), lint steady at 31 pre-existing warnings.

Note: `mix()`/a11y still only accept raw object inputs — string/Color-instance acceptance is the README-contract work in PR 5 of this series.

---
Ultracode audit fix series (PR 3/10).