### PR TITLE
fix(parse): CSS-conformant parser grammar with type/runtime parity

### DIFF
--- a/packages/use-color/src/__tests__/property.test.ts
+++ b/packages/use-color/src/__tests__/property.test.ts
@@ -169,7 +169,13 @@ describe("Property: Parse ∘ Format = Identity", () => {
 					expect(parsed.l).toBeCloseTo(oklch.l, 5);
 					expect(parsed.c).toBeCloseTo(oklch.c, 5);
 					if (oklch.c > 0.001) {
-						expect(parsed.h).toBeCloseTo(oklch.h, 3);
+						// Hue is circular: a source hue that rounds up to exactly 360
+						// when formatted (e.g. 359.9999995 at precision 6) normalizes
+						// to 0 on parse, so compare the wraparound-aware distance
+						// rather than the raw difference.
+						const hueDiff = Math.abs(parsed.h - oklch.h);
+						const circularHueDiff = Math.min(hueDiff, 360 - hueDiff);
+						expect(circularHueDiff).toBeCloseTo(0, 3);
 					}
 					expect(parsed.a).toBeCloseTo(oklch.a, 5);
 				}),

--- a/packages/use-color/src/parse/__tests__/hex.test.ts
+++ b/packages/use-color/src/parse/__tests__/hex.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ColorErrorCode, ColorParseError } from "../../errors.js";
+import { toHex8 } from "../../format/hex.js";
 import { parseHex, parseHex3, parseHex4, parseHex6, parseHex8, tryParseHex } from "../hex.js";
 
 describe("parseHex3", () => {
@@ -321,6 +322,39 @@ describe("tryParseHex", () => {
 				expect(error.message).toBeDefined();
 				expect(error.code).toBeDefined();
 			}
+		});
+	});
+
+	describe("alpha byte round-trip precision", () => {
+		it("parseHex8(toHex8(...)) round-trips every possible alpha byte (0-255) exactly", () => {
+			for (let byte = 0; byte <= 255; byte++) {
+				const hex = `#ff0000${byte.toString(16).padStart(2, "0")}`;
+				const parsed = parseHex8(hex);
+				const formatted = toHex8(parsed);
+				expect(formatted).toBe(hex);
+			}
+		});
+
+		it("parseHex4(toHex8(...)) round-trips every possible alpha nibble (0-15) exactly", () => {
+			for (let nibble = 0; nibble <= 15; nibble++) {
+				const hex = `#f00${nibble.toString(16)}`;
+				const parsed = parseHex4(hex);
+				// 4-digit alpha nibble is expanded to a byte (nibble repeated), so
+				// compare against the expanded 8-digit form rather than the input.
+				const expandedByte = nibble * 16 + nibble;
+				const formatted = toHex8(parsed);
+				expect(formatted).toBe(`#ff0000${expandedByte.toString(16).padStart(2, "0")}`);
+			}
+		});
+
+		it("preserves distinct alpha bytes without collapsing to 2-decimal precision", () => {
+			// Previously alpha was rounded to 2 decimals at parse time, which
+			// collapsed distinct nearby bytes (e.g. 128 and 129) to the same value.
+			const a128 = parseHex8("#ff000080").a;
+			const a129 = parseHex8("#ff000081").a;
+			expect(a128).not.toBe(a129);
+			expect(a128).toBeCloseTo(128 / 255, 10);
+			expect(a129).toBeCloseTo(129 / 255, 10);
 		});
 	});
 });

--- a/packages/use-color/src/parse/__tests__/hsl.test.ts
+++ b/packages/use-color/src/parse/__tests__/hsl.test.ts
@@ -114,12 +114,71 @@ describe("parseHslLegacy", () => {
 		expect(() => parseHslLegacy("hsl()")).toThrow();
 		expect(() => parseHslLegacy("hsl(0)")).toThrow();
 		expect(() => parseHslLegacy("hsl(0, 100%)")).toThrow();
-		expect(() => parseHslLegacy("hsl(0, 100%, 50%, 1)")).toThrow();
 		expect(() => parseHslLegacy("rgb(0, 100%, 50%)")).toThrow();
 	});
 
 	it("throws on non-percentage saturation/lightness", () => {
 		expect(() => parseHslLegacy("hsl(0, 100, 50)")).toThrow();
+	});
+
+	// CSS Color 4 makes hsl()/hsla() exact aliases, so the 3-arg legacy `hsl(...)`
+	// form also accepts a 4th alpha value (previously this silently threw).
+	it("parses hsl(h, s%, l%, a) with an explicit alpha (hsl/hsla alias)", () => {
+		expect(parseHslLegacy("hsl(0, 100%, 50%, 1)")).toEqual({
+			h: 0,
+			s: 1,
+			l: 0.5,
+			a: 1,
+		});
+		expect(parseHslLegacy("hsl(120, 50%, 50%, 0.5)")).toEqual({
+			h: 120,
+			s: 0.5,
+			l: 0.5,
+			a: 0.5,
+		});
+	});
+
+	it("parses alpha as percentage in hsl(h, s%, l%, a%)", () => {
+		expect(parseHslLegacy("hsl(180, 50%, 50%, 50%)")).toEqual({
+			h: 180,
+			s: 0.5,
+			l: 0.5,
+			a: 0.5,
+		});
+	});
+
+	it("clamps out-of-range alpha in hsl(h, s%, l%, a)", () => {
+		expect(parseHslLegacy("hsl(0, 100%, 50%, 1.5)")).toEqual({
+			h: 0,
+			s: 1,
+			l: 0.5,
+			a: 1,
+		});
+		expect(parseHslLegacy("hsl(0, 100%, 50%, -0.5)")).toEqual({
+			h: 0,
+			s: 1,
+			l: 0.5,
+			a: 0,
+		});
+	});
+
+	it("throws on multi-dot hue instead of silently truncating", () => {
+		// parseFloat("1.2.3") would silently truncate to 1.2; the strict
+		// number token must reject the whole match instead.
+		expect(() => parseHslLegacy("hsl(1.2.3, 100%, 50%)")).toThrow();
+	});
+
+	it("throws on trailing garbage after the hue value", () => {
+		expect(() => parseHslLegacy("hsl(0deg, 100%, 50%)")).toThrow();
+	});
+
+	it("accepts scientific notation", () => {
+		expect(parseHslLegacy("hsl(1.2e2, 1e2%, 5e1%, 5e-1)")).toEqual({
+			h: 120,
+			s: 1,
+			l: 0.5,
+			a: 0.5,
+		});
 	});
 });
 

--- a/packages/use-color/src/parse/__tests__/oklch.test.ts
+++ b/packages/use-color/src/parse/__tests__/oklch.test.ts
@@ -135,6 +135,28 @@ describe("parseOklch", () => {
 			const result = parseOklch("oklch(0.5 0.2 180 / 1)");
 			expect(result).toEqual({ l: 0.5, c: 0.2, h: 180, a: 1 });
 		});
+
+		// CSS <alpha-value> accepts signed values and clamps to [0, 1] at
+		// parse time — negative alpha is valid syntax, not an error.
+		it("clamps negative alpha to 0 (oklch(50% .2 30 / -20%))", () => {
+			const result = parseOklch("oklch(50% .2 30 / -20%)");
+			expect(result.a).toBe(0);
+		});
+
+		it("clamps alpha above 1 (oklch(50% .2 30 / 200%))", () => {
+			const result = parseOklch("oklch(50% .2 30 / 200%)");
+			expect(result.a).toBe(1);
+		});
+
+		it("clamps numeric alpha above 1 (oklch(0.5 0.2 180 / 2))", () => {
+			const result = parseOklch("oklch(0.5 0.2 180 / 2)");
+			expect(result.a).toBe(1);
+		});
+
+		it("clamps negative numeric alpha (oklch(0.5 0.2 180 / -0.5))", () => {
+			const result = parseOklch("oklch(0.5 0.2 180 / -0.5)");
+			expect(result.a).toBe(0);
+		});
 	});
 
 	describe("whitespace handling", () => {

--- a/packages/use-color/src/parse/__tests__/oklch.test.ts
+++ b/packages/use-color/src/parse/__tests__/oklch.test.ts
@@ -9,9 +9,9 @@ describe("parseOklch", () => {
 			expect(result).toEqual({ l: 0.5, c: 0.2, h: 180, a: 1 });
 		});
 
-		it("parses oklch(1 0.4 360)", () => {
+		it("parses oklch(1 0.4 360) - hue normalized to [0, 360), so 360 wraps to 0", () => {
 			const result = parseOklch("oklch(1 0.4 360)");
-			expect(result).toEqual({ l: 1, c: 0.4, h: 360, a: 1 });
+			expect(result).toEqual({ l: 1, c: 0.4, h: 0, a: 1 });
 		});
 
 		it("parses oklch(0 0 0)", () => {
@@ -26,9 +26,9 @@ describe("parseOklch", () => {
 			expect(result).toEqual({ l: 0.5, c: 0.2, h: 180, a: 1 });
 		});
 
-		it("parses oklch(100% 0.4 360)", () => {
+		it("parses oklch(100% 0.4 360) - hue normalized to [0, 360), so 360 wraps to 0", () => {
 			const result = parseOklch("oklch(100% 0.4 360)");
-			expect(result).toEqual({ l: 1, c: 0.4, h: 360, a: 1 });
+			expect(result).toEqual({ l: 1, c: 0.4, h: 0, a: 1 });
 		});
 
 		it("parses oklch(0% 0 0)", () => {
@@ -164,6 +164,55 @@ describe("parseOklch", () => {
 		});
 	});
 
+	describe("hue normalization", () => {
+		it("normalizes negative hue: oklch(0.5 0.2 -90) -> h: 270", () => {
+			const result = parseOklch("oklch(0.5 0.2 -90)");
+			expect(result).toEqual({ l: 0.5, c: 0.2, h: 270, a: 1 });
+		});
+
+		it("normalizes negative hue: oklch(0.5 0.2 -1) -> h: 359", () => {
+			const result = parseOklch("oklch(0.5 0.2 -1)");
+			expect(result.h).toBeCloseTo(359, 5);
+		});
+
+		it("normalizes hue beyond 360: oklch(0.5 0.2 720) -> h: 0", () => {
+			const result = parseOklch("oklch(0.5 0.2 720)");
+			expect(result.h).toBe(0);
+		});
+
+		it("normalizes explicit +hue sign: oklch(0.5 0.2 +90)", () => {
+			const result = parseOklch("oklch(0.5 0.2 +90)");
+			expect(result.h).toBe(90);
+		});
+	});
+
+	describe("L/C range clamping", () => {
+		it("clamps L > 1 to 1: oklch(1.5 0.2 180)", () => {
+			const result = parseOklch("oklch(1.5 0.2 180)");
+			expect(result).toEqual({ l: 1, c: 0.2, h: 180, a: 1 });
+		});
+
+		it("clamps negative L to 0: oklch(-0.5 0.2 180)", () => {
+			const result = parseOklch("oklch(-0.5 0.2 180)");
+			expect(result).toEqual({ l: 0, c: 0.2, h: 180, a: 1 });
+		});
+
+		it("clamps negative C to 0: oklch(0.5 -0.2 180)", () => {
+			const result = parseOklch("oklch(0.5 -0.2 180)");
+			expect(result).toEqual({ l: 0.5, c: 0, h: 180, a: 1 });
+		});
+
+		it("clamps both negative L and C: oklch(-1 -0.5 180)", () => {
+			const result = parseOklch("oklch(-1 -0.5 180)");
+			expect(result).toEqual({ l: 0, c: 0, h: 180, a: 1 });
+		});
+
+		it("does not clamp high out-of-gamut chroma (only negative C is clamped)", () => {
+			const result = parseOklch("oklch(0.5 2 180)");
+			expect(result).toEqual({ l: 0.5, c: 2, h: 180, a: 1 });
+		});
+	});
+
 	describe("edge cases - high chroma (out-of-gamut)", () => {
 		it("parses oklch(0.5 0.5 180) - high chroma", () => {
 			const result = parseOklch("oklch(0.5 0.5 180)");
@@ -232,6 +281,29 @@ describe("parseOklch", () => {
 				expect(e).toBeInstanceOf(ColorParseError);
 				expect((e as ColorParseError).code).toBe(ColorErrorCode.INVALID_OKLCH);
 			}
+		});
+
+		it("throws on multi-dot numbers instead of silently truncating", () => {
+			// parseFloat("1.2.3") would silently truncate to 1.2; the strict
+			// number token must reject the whole match instead.
+			expect(() => parseOklch("oklch(0.5.1 0.2 180)")).toThrow(ColorParseError);
+			expect(() => parseOklch("oklch(0.5 0.2.1 180)")).toThrow(ColorParseError);
+			expect(() => parseOklch("oklch(0.5 0.2 180.1.1)")).toThrow(ColorParseError);
+		});
+
+		it("throws on trailing garbage after a numeric value", () => {
+			expect(() => parseOklch("oklch(0.5deg 0.2 180)")).toThrow(ColorParseError);
+		});
+	});
+
+	describe("scientific notation", () => {
+		it("accepts scientific notation for L, C, and H", () => {
+			expect(parseOklch("oklch(5e-1 2e-1 1.8e2)")).toEqual({
+				l: 0.5,
+				c: 0.2,
+				h: 180,
+				a: 1,
+			});
 		});
 	});
 });

--- a/packages/use-color/src/parse/__tests__/rgb.test.ts
+++ b/packages/use-color/src/parse/__tests__/rgb.test.ts
@@ -82,6 +82,42 @@ describe("parseRgbLegacy", () => {
 		});
 	});
 
+	// CSS Color 4 makes rgb()/rgba() exact aliases, so the 3-arg legacy
+	// `rgb(...)` form also accepts a 4th alpha value (previously this
+	// silently dropped the alpha, parsing as fully opaque).
+	it("parses rgb(r, g, b, a) with an explicit alpha (rgb/rgba alias)", () => {
+		expect(parseRgbLegacy("rgb(255, 0, 0, 0.5)")).toEqual({
+			r: 255,
+			g: 0,
+			b: 0,
+			a: 0.5,
+		});
+	});
+
+	it("parses alpha as percentage in rgb(r, g, b, a%)", () => {
+		expect(parseRgbLegacy("rgb(255, 0, 0, 50%)")).toEqual({
+			r: 255,
+			g: 0,
+			b: 0,
+			a: 0.5,
+		});
+	});
+
+	it("clamps out-of-range alpha in rgb(r, g, b, a)", () => {
+		expect(parseRgbLegacy("rgb(255, 0, 0, 5000)")).toEqual({
+			r: 255,
+			g: 0,
+			b: 0,
+			a: 1,
+		});
+		expect(parseRgbLegacy("rgb(255, 0, 0, -5)")).toEqual({
+			r: 255,
+			g: 0,
+			b: 0,
+			a: 0,
+		});
+	});
+
 	it("throws on invalid format", () => {
 		expect(() => parseRgbLegacy("rgb(255 0 0)")).toThrow(ColorParseError);
 		expect(() => parseRgbLegacy("rgba(255, 0, 0, 1)")).toThrow(ColorParseError);
@@ -91,6 +127,25 @@ describe("parseRgbLegacy", () => {
 	it("throws on invalid values", () => {
 		expect(() => parseRgbLegacy("rgb(abc, 0, 0)")).toThrow(ColorParseError);
 		expect(() => parseRgbLegacy("rgb(, 0, 0)")).toThrow(ColorParseError);
+	});
+
+	it("throws on multi-dot numbers instead of silently truncating", () => {
+		// parseFloat("1.2.3") would silently truncate to 1.2; the strict
+		// number token must reject the whole match instead.
+		expect(() => parseRgbLegacy("rgb(1.2.3, 0, 0)")).toThrow(ColorParseError);
+	});
+
+	it("throws on trailing garbage after a numeric value", () => {
+		expect(() => parseRgbLegacy("rgb(255px, 0, 0)")).toThrow(ColorParseError);
+	});
+
+	it("accepts scientific notation", () => {
+		expect(parseRgbLegacy("rgb(2.55e2, 0e0, 0, 5e-1)")).toEqual({
+			r: 255,
+			g: 0,
+			b: 0,
+			a: 0.5,
+		});
 	});
 
 	it("throws on invalid percentage values like abc%", () => {

--- a/packages/use-color/src/parse/hex.ts
+++ b/packages/use-color/src/parse/hex.ts
@@ -18,7 +18,10 @@ function hexToInt(hex: string): number {
 }
 
 function hexToAlpha(hex: string): number {
-	return Math.round((hexToInt(hex) / 255) * 100) / 100;
+	// Store full precision here; rounding happens only at format time
+	// (see format/hex.ts's alphaToHex), so parse -> format round-trips
+	// exactly for every possible alpha byte (0-255).
+	return hexToInt(hex) / 255;
 }
 
 export function parseHex3(str: string): RGBA {

--- a/packages/use-color/src/parse/hsl.ts
+++ b/packages/use-color/src/parse/hsl.ts
@@ -29,6 +29,7 @@
 import { ColorErrorCode, ColorParseError } from "../errors.js";
 import type { HSLA } from "../types/color.js";
 import { err, ok, type Result } from "../types/Result.js";
+import { NUM, NUM_OPT_PCT, NUM_PCT } from "./number.js";
 
 /**
  * Normalizes a hue value to the range [0, 360).
@@ -97,37 +98,48 @@ function clamp01(value: number): number {
 }
 
 /**
- * Regex for legacy HSL format: hsl(h, s%, l%)
- * Captures: hue, saturation%, lightness%
+ * Regex for legacy HSL format: hsl(h, s%, l%), with optional alpha: hsl(h, s%, l%, a)
+ * Captures: hue, saturation%, lightness%, optional alpha
+ * (CSS Color 4 makes hsl()/hsla() exact aliases, so the 3-arg legacy form also
+ * accepts a 4th alpha value.)
  */
-const HSL_LEGACY_REGEX = /^hsl\(\s*([+-]?[\d.]+)\s*,\s*([+-]?[\d.]+%)\s*,\s*([+-]?[\d.]+%)\s*\)$/i;
+const HSL_LEGACY_REGEX = new RegExp(
+	`^hsl\\(\\s*(${NUM})\\s*,\\s*(${NUM_PCT})\\s*,\\s*(${NUM_PCT})\\s*(?:,\\s*(${NUM_OPT_PCT})\\s*)?\\)$`,
+	"i",
+);
 
 /**
  * Regex for legacy HSLA format: hsla(h, s%, l%, a)
  * Captures: hue, saturation%, lightness%, alpha
  */
-const HSLA_LEGACY_REGEX =
-	/^hsla\(\s*([+-]?[\d.]+)\s*,\s*([+-]?[\d.]+%)\s*,\s*([+-]?[\d.]+%)\s*,\s*([+-]?[\d.]+%?)\s*\)$/i;
+const HSLA_LEGACY_REGEX = new RegExp(
+	`^hsla\\(\\s*(${NUM})\\s*,\\s*(${NUM_PCT})\\s*,\\s*(${NUM_PCT})\\s*,\\s*(${NUM_OPT_PCT})\\s*\\)$`,
+	"i",
+);
 
 /**
  * Regex for modern CSS4 HSL format: hsl(h s% l%) or hsl(h s% l% / a)
  * Captures: hue, saturation%, lightness%, optional alpha
  */
-const HSL_MODERN_REGEX =
-	/^hsl\(\s*([+-]?[\d.]+)\s+([+-]?[\d.]+%)\s+([+-]?[\d.]+%)(?:\s*\/\s*([+-]?[\d.]+%?))?\s*\)$/i;
+const HSL_MODERN_REGEX = new RegExp(
+	`^hsl\\(\\s*(${NUM})\\s+(${NUM_PCT})\\s+(${NUM_PCT})(?:\\s*\\/\\s*(${NUM_OPT_PCT}))?\\s*\\)$`,
+	"i",
+);
 
 /**
  * Regex for modern CSS4 HSLA format: hsla(h s% l% / a)
  * Note: In CSS4, hsla() is an alias for hsl() with space syntax
  */
-const HSLA_MODERN_REGEX =
-	/^hsla\(\s*([+-]?[\d.]+)\s+([+-]?[\d.]+%)\s+([+-]?[\d.]+%)(?:\s*\/\s*([+-]?[\d.]+%?))?\s*\)$/i;
+const HSLA_MODERN_REGEX = new RegExp(
+	`^hsla\\(\\s*(${NUM})\\s+(${NUM_PCT})\\s+(${NUM_PCT})(?:\\s*\\/\\s*(${NUM_OPT_PCT}))?\\s*\\)$`,
+	"i",
+);
 
 /**
  * Parses a legacy HSL string: `hsl(h, s%, l%)`
  *
  * @param str - The HSL string to parse
- * @returns HSLA object with alpha = 1
+ * @returns HSLA object with alpha = 1 (or the parsed 4th value, if present)
  * @throws ColorParseError if the string is not valid legacy HSL format
  *
  * @example
@@ -137,6 +149,9 @@ const HSLA_MODERN_REGEX =
  *
  * parseHslLegacy('hsl(180, 50%, 25%)');
  * // { h: 180, s: 0.5, l: 0.25, a: 1 }
+ *
+ * parseHslLegacy('hsl(120, 50%, 50%, 0.5)');
+ * // { h: 120, s: 0.5, l: 0.5, a: 0.5 }
  * ```
  */
 export function parseHslLegacy(str: string): HSLA {
@@ -145,17 +160,24 @@ export function parseHslLegacy(str: string): HSLA {
 	if (!match) {
 		throw new ColorParseError(
 			ColorErrorCode.INVALID_HSL,
-			`Invalid legacy HSL format: "${str}". Expected format: hsl(h, s%, l%)`,
+			`Invalid legacy HSL format: "${str}". Expected format: hsl(h, s%, l%) or hsl(h, s%, l%, a)`,
 		);
 	}
 
-	const [, hueStr, satStr, lightStr] = match as [string, string, string, string];
+	const [, hueStr, satStr, lightStr, alphaStr] = match as [
+		string,
+		string,
+		string,
+		string,
+		string | undefined,
+	];
 
 	const hue = parseFloat(hueStr);
 	const sat = parsePercentage(satStr);
 	const light = parsePercentage(lightStr);
+	const alpha = alphaStr !== undefined ? parseAlpha(alphaStr) : 1;
 
-	if (Number.isNaN(hue) || Number.isNaN(sat) || Number.isNaN(light)) {
+	if (Number.isNaN(hue) || Number.isNaN(sat) || Number.isNaN(light) || Number.isNaN(alpha)) {
 		throw new ColorParseError(ColorErrorCode.INVALID_HSL, `Invalid HSL values in: "${str}"`);
 	}
 
@@ -163,7 +185,7 @@ export function parseHslLegacy(str: string): HSLA {
 		h: normalizeHue(hue),
 		s: clamp01(sat),
 		l: clamp01(light),
-		a: 1,
+		a: clamp01(alpha),
 	};
 }
 

--- a/packages/use-color/src/parse/number.ts
+++ b/packages/use-color/src/parse/number.ts
@@ -25,10 +25,3 @@ export const NUM_PCT = `${NUM}%`;
 
 /** Strict numeric token with an optional trailing percent sign. */
 export const NUM_OPT_PCT = `${NUM}%?`;
-
-/**
- * Strict unsigned numeric token (no leading sign) with an optional trailing
- * percent sign. Used for slots (like alpha) where a leading sign was never
- * part of the accepted grammar.
- */
-export const NUM_UNSIGNED_OPT_PCT = `${NUM_BODY}%?`;

--- a/packages/use-color/src/parse/number.ts
+++ b/packages/use-color/src/parse/number.ts
@@ -1,0 +1,34 @@
+/**
+ * @module parse/number
+ *
+ * Shared strict number-token regex source used across color parsers.
+ *
+ * A "strict" number token is one that consumes exactly what `Number.parseFloat`
+ * would consume and nothing more — so composing it into a larger anchored
+ * regex means malformed tokens (e.g. multi-dot numbers like "1.2.3", or
+ * trailing garbage) fail to match at all, instead of being silently
+ * truncated by `parseFloat`.
+ *
+ * Scientific notation (e.g. "1e2") is accepted everywhere for CSS
+ * conformance, matching how `${number}` template-literal types already
+ * accept exponential numeric strings.
+ */
+
+/** Unsigned numeric body: integer/decimal digits, optional exponent (no sign). */
+const NUM_BODY = "(?:\\d+\\.?\\d*|\\.\\d+)(?:[eE][+-]?\\d+)?";
+
+/** Strict numeric token: optional sign, integer/decimal digits, optional exponent. */
+export const NUM = `[+-]?${NUM_BODY}`;
+
+/** Strict numeric token with a required trailing percent sign. */
+export const NUM_PCT = `${NUM}%`;
+
+/** Strict numeric token with an optional trailing percent sign. */
+export const NUM_OPT_PCT = `${NUM}%?`;
+
+/**
+ * Strict unsigned numeric token (no leading sign) with an optional trailing
+ * percent sign. Used for slots (like alpha) where a leading sign was never
+ * part of the accepted grammar.
+ */
+export const NUM_UNSIGNED_OPT_PCT = `${NUM_BODY}%?`;

--- a/packages/use-color/src/parse/oklch.ts
+++ b/packages/use-color/src/parse/oklch.ts
@@ -1,10 +1,18 @@
 import { ColorErrorCode, ColorParseError } from "../errors.js";
 import type { OKLCH } from "../types/color.js";
 import { err, ok, type Result } from "../types/Result.js";
+import { normalizeHue } from "./hsl.js";
+import { NUM, NUM_OPT_PCT, NUM_UNSIGNED_OPT_PCT } from "./number.js";
 
-/** Matches: oklch(L C H) or oklch(L C H / A) where L, C, and A can be percentages */
-const OKLCH_REGEX =
-	/^oklch\(\s*([0-9.]+%?)\s+([0-9.]+%?)\s+([0-9.]+)\s*(?:\/\s*([0-9.]+%?))?\s*\)$/i;
+/**
+ * Matches: oklch(L C H) or oklch(L C H / A) where L, C, and A can be percentages.
+ * Hue accepts a leading sign (negative hues arise from hue arithmetic and are
+ * normalized into [0, 360) after parsing). Alpha does not accept a sign.
+ */
+const OKLCH_REGEX = new RegExp(
+	`^oklch\\(\\s*(${NUM_OPT_PCT})\\s+(${NUM_OPT_PCT})\\s+(${NUM})\\s*(?:\\/\\s*(${NUM_UNSIGNED_OPT_PCT}))?\\s*\\)$`,
+	"i",
+);
 
 function parsePercentageOrNumber(value: string, scale = 1): number {
 	if (value.endsWith("%")) {
@@ -31,6 +39,8 @@ function isValidOklch(oklch: OKLCH): boolean {
  * parseOklch('oklch(0.5 0.2 180)');      // { l: 0.5, c: 0.2, h: 180, a: 1 }
  * parseOklch('oklch(50% 0.2 180)');      // { l: 0.5, c: 0.2, h: 180, a: 1 }
  * parseOklch('oklch(0.5 0.2 180 / 0.5)'); // { l: 0.5, c: 0.2, h: 180, a: 0.5 }
+ * parseOklch('oklch(0.5 0.2 -90)');      // { l: 0.5, c: 0.2, h: 270, a: 1 } (negative hue normalized)
+ * parseOklch('oklch(1.5 0.2 180)');      // { l: 1, c: 0.2, h: 180, a: 1 } (L clamped to [0, 1])
  */
 export function parseOklch(str: string): OKLCH {
 	const result = tryParseOklch(str);
@@ -64,12 +74,18 @@ export function tryParseOklch(str: string): Result<OKLCH, ColorParseError> {
 
 	const [, lStr, cStr, hStr, aStr] = match;
 
-	const l = parsePercentageOrNumber(lStr!, 1);
-	const c = parsePercentageOrNumber(cStr!, 0.4);
-	const h = parseFloat(hStr!);
+	const lRaw = parsePercentageOrNumber(lStr!, 1);
+	const cRaw = parsePercentageOrNumber(cStr!, 0.4);
+	const h = normalizeHue(parseFloat(hStr!));
 	const a = aStr !== undefined ? parsePercentageOrNumber(aStr, 1) : 1;
 
-	const oklch: OKLCH = { l, c, h, a };
+	// CSS clamps out-of-range L/C rather than rejecting them: L to [0, 1], C to [0, ∞).
+	const oklch: OKLCH = {
+		l: Math.max(0, Math.min(1, lRaw)),
+		c: Math.max(0, cRaw),
+		h,
+		a,
+	};
 
 	/* v8 ignore start - regex ensures numeric patterns */
 	if (!isValidOklch(oklch)) {

--- a/packages/use-color/src/parse/oklch.ts
+++ b/packages/use-color/src/parse/oklch.ts
@@ -2,15 +2,16 @@ import { ColorErrorCode, ColorParseError } from "../errors.js";
 import type { OKLCH } from "../types/color.js";
 import { err, ok, type Result } from "../types/Result.js";
 import { normalizeHue } from "./hsl.js";
-import { NUM, NUM_OPT_PCT, NUM_UNSIGNED_OPT_PCT } from "./number.js";
+import { NUM, NUM_OPT_PCT } from "./number.js";
 
 /**
  * Matches: oklch(L C H) or oklch(L C H / A) where L, C, and A can be percentages.
  * Hue accepts a leading sign (negative hues arise from hue arithmetic and are
- * normalized into [0, 360) after parsing). Alpha does not accept a sign.
+ * normalized into [0, 360) after parsing). Alpha accepts a sign per the CSS
+ * `<alpha-value>` grammar; out-of-range values clamp to [0, 1] at parse time.
  */
 const OKLCH_REGEX = new RegExp(
-	`^oklch\\(\\s*(${NUM_OPT_PCT})\\s+(${NUM_OPT_PCT})\\s+(${NUM})\\s*(?:\\/\\s*(${NUM_UNSIGNED_OPT_PCT}))?\\s*\\)$`,
+	`^oklch\\(\\s*(${NUM_OPT_PCT})\\s+(${NUM_OPT_PCT})\\s+(${NUM})\\s*(?:\\/\\s*(${NUM_OPT_PCT}))?\\s*\\)$`,
 	"i",
 );
 
@@ -77,14 +78,15 @@ export function tryParseOklch(str: string): Result<OKLCH, ColorParseError> {
 	const lRaw = parsePercentageOrNumber(lStr!, 1);
 	const cRaw = parsePercentageOrNumber(cStr!, 0.4);
 	const h = normalizeHue(parseFloat(hStr!));
-	const a = aStr !== undefined ? parsePercentageOrNumber(aStr, 1) : 1;
+	const aRaw = aStr !== undefined ? parsePercentageOrNumber(aStr, 1) : 1;
 
-	// CSS clamps out-of-range L/C rather than rejecting them: L to [0, 1], C to [0, ∞).
+	// CSS clamps out-of-range values rather than rejecting them:
+	// L to [0, 1], C to [0, ∞), and alpha (like every <alpha-value>) to [0, 1].
 	const oklch: OKLCH = {
 		l: Math.max(0, Math.min(1, lRaw)),
 		c: Math.max(0, cRaw),
 		h,
-		a,
+		a: Math.max(0, Math.min(1, aRaw)),
 	};
 
 	/* v8 ignore start - regex ensures numeric patterns */

--- a/packages/use-color/src/parse/rgb.ts
+++ b/packages/use-color/src/parse/rgb.ts
@@ -26,6 +26,7 @@
 import { ColorErrorCode, ColorParseError } from "../errors.js";
 import type { RGBA } from "../types/color.js";
 import { err, ok, type Result } from "../types/Result.js";
+import { NUM_OPT_PCT } from "./number.js";
 
 /**
  * Clamps a value to the RGB range (0-255).
@@ -72,12 +73,22 @@ const parseColorValue = (value: string, isAlpha = false): number => {
  * Regular expression patterns for RGB string matching.
  */
 const RGB_PATTERNS = {
-	// Legacy: rgb(255, 0, 0) or rgb(255,0,0)
-	legacy: /^rgb\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^)]+)\s*\)$/i,
+	// Legacy: rgb(255, 0, 0) or rgb(255,0,0), with optional alpha: rgb(255, 0, 0, 0.5)
+	// (CSS Color 4 makes rgb()/rgba() exact aliases, so the 3-arg legacy form also accepts a 4th alpha value)
+	legacy: new RegExp(
+		`^rgb\\(\\s*(${NUM_OPT_PCT})\\s*,\\s*(${NUM_OPT_PCT})\\s*,\\s*(${NUM_OPT_PCT})\\s*(?:,\\s*(${NUM_OPT_PCT})\\s*)?\\)$`,
+		"i",
+	),
 	// Legacy: rgba(255, 0, 0, 0.5) or rgba(255,0,0,0.5)
-	legacyAlpha: /^rgba\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^)]+)\s*\)$/i,
+	legacyAlpha: new RegExp(
+		`^rgba\\(\\s*(${NUM_OPT_PCT})\\s*,\\s*(${NUM_OPT_PCT})\\s*,\\s*(${NUM_OPT_PCT})\\s*,\\s*(${NUM_OPT_PCT})\\s*\\)$`,
+		"i",
+	),
 	// Modern: rgb(255 0 0) or rgb(255 0 0 / 0.5) - values must be numbers or percentages (no commas)
-	modern: /^rgb\(\s*(-?[\d.]+%?)\s+(-?[\d.]+%?)\s+(-?[\d.]+%?)(?:\s*\/\s*(-?[\d.]+%?))?\s*\)$/i,
+	modern: new RegExp(
+		`^rgb\\(\\s*(${NUM_OPT_PCT})\\s+(${NUM_OPT_PCT})\\s+(${NUM_OPT_PCT})(?:\\s*\\/\\s*(${NUM_OPT_PCT}))?\\s*\\)$`,
+		"i",
+	),
 	// Detect if string looks like an RGB function
 	isRgb: /^rgba?\(/i,
 } as const;
@@ -91,8 +102,9 @@ const RGB_PATTERNS = {
  *
  * @example
  * ```typescript
- * parseRgbLegacy('rgb(255, 0, 0)');     // { r: 255, g: 0, b: 0, a: 1 }
- * parseRgbLegacy('rgb(100%, 0%, 0%)'); // { r: 255, g: 0, b: 0, a: 1 }
+ * parseRgbLegacy('rgb(255, 0, 0)');       // { r: 255, g: 0, b: 0, a: 1 }
+ * parseRgbLegacy('rgb(100%, 0%, 0%)');   // { r: 255, g: 0, b: 0, a: 1 }
+ * parseRgbLegacy('rgb(255, 0, 0, 0.5)'); // { r: 255, g: 0, b: 0, a: 0.5 }
  * ```
  */
 export function parseRgbLegacy(str: string): RGBA {
@@ -101,16 +113,17 @@ export function parseRgbLegacy(str: string): RGBA {
 	if (!match) {
 		throw new ColorParseError(
 			ColorErrorCode.INVALID_RGB,
-			`Invalid legacy RGB format: "${str}". Expected format: rgb(r, g, b)`,
+			`Invalid legacy RGB format: "${str}". Expected format: rgb(r, g, b) or rgb(r, g, b, a)`,
 		);
 	}
 
-	const [, rStr, gStr, bStr] = match;
+	const [, rStr, gStr, bStr, aStr] = match;
 	const r = parseColorValue(rStr!);
 	const g = parseColorValue(gStr!);
 	const b = parseColorValue(bStr!);
+	const a = aStr !== undefined ? parseColorValue(aStr, true) : 1;
 
-	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+	if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) || Number.isNaN(a)) {
 		throw new ColorParseError(
 			ColorErrorCode.INVALID_RGB,
 			`Invalid RGB values in: "${str}". Values must be numbers or percentages.`,
@@ -121,7 +134,7 @@ export function parseRgbLegacy(str: string): RGBA {
 		r: clampRgb(r),
 		g: clampRgb(g),
 		b: clampRgb(b),
-		a: 1,
+		a: clampAlpha(a),
 	};
 }
 

--- a/packages/use-color/src/types/Hsl.ts
+++ b/packages/use-color/src/types/Hsl.ts
@@ -71,6 +71,15 @@ type HslaLegacyPattern =
 	`hsla(${NumberString}${CommaSep}${PercentString}${CommaSep}${PercentString}${CommaSep}${AlphaValue})`;
 
 /**
+ * Pattern for legacy HSL format with alpha: hsl(h, s%, l%, a)
+ * CSS Color 4 makes hsl()/hsla() exact aliases, so the 3-arg legacy `hsl(...)`
+ * form also accepts a 4th alpha value.
+ * @internal
+ */
+type HslLegacyAlphaPattern =
+	`hsl(${NumberString}${CommaSep}${PercentString}${CommaSep}${PercentString}${CommaSep}${AlphaValue})`;
+
+/**
  * Validates legacy HSL format: `hsl(h, s%, l%)`
  *
  * @example
@@ -93,6 +102,22 @@ export type HslLegacyString<T extends string> = [T] extends [HslLegacyPattern] ?
  * ```
  */
 export type HslaLegacyString<T extends string> = [T] extends [HslaLegacyPattern] ? T : never;
+
+/**
+ * Validates legacy HSL format with alpha: `hsl(h, s%, l%, a)`
+ *
+ * CSS Color 4 makes hsl()/hsla() exact aliases, so the 3-arg legacy `hsl(...)`
+ * form also accepts a 4th alpha value.
+ *
+ * @example
+ * ```ts
+ * type A = HslLegacyAlphaString<'hsl(120, 50%, 50%, 0.5)'>;  // valid
+ * type B = HslLegacyAlphaString<'hsl(180, 50%, 50%)'>;       // never (no alpha)
+ * ```
+ */
+export type HslLegacyAlphaString<T extends string> = [T] extends [HslLegacyAlphaPattern]
+	? T
+	: never;
 
 // ============================================================================
 // Modern HSL (CSS Level 4 space-separated)
@@ -183,7 +208,10 @@ export type HslString<T extends string> = HslLegacyString<T> | HslModernString<T
  * type B = HslaString<'hsl(180 50% 50% / 0.5)'>;    // modern
  * ```
  */
-export type HslaString<T extends string> = HslaLegacyString<T> | HslModernAlphaString<T>;
+export type HslaString<T extends string> =
+	| HslaLegacyString<T>
+	| HslLegacyAlphaString<T>
+	| HslModernAlphaString<T>;
 
 /**
  * Unified HSL/HSLA color string validator.
@@ -209,5 +237,6 @@ export type HslaString<T extends string> = HslaLegacyString<T> | HslModernAlphaS
 export type HslInputString<T extends string> =
 	| HslLegacyString<T>
 	| HslaLegacyString<T>
+	| HslLegacyAlphaString<T>
 	| HslModernString<T>
 	| HslModernAlphaString<T>;

--- a/packages/use-color/src/types/Rgb.test-d.ts
+++ b/packages/use-color/src/types/Rgb.test-d.ts
@@ -4,6 +4,7 @@ import type {
 	Digit,
 	NumberString,
 	RgbaFunctionString,
+	RgbFunctionAlphaString,
 	RgbFunctionString,
 	RgbModernString,
 	RgbString,
@@ -189,5 +190,27 @@ describe("Rgb types", () => {
 		expectTypeOf<RgbString<"rgba(255, 255, 255, 1)">>().toEqualTypeOf<"rgba(255, 255, 255, 1)">();
 		expectTypeOf<RgbString<"rgb(0 0 0)">>().toEqualTypeOf<"rgb(0 0 0)">();
 		expectTypeOf<RgbString<"rgb(255 255 255 / 1)">>().toEqualTypeOf<"rgb(255 255 255 / 1)">();
+	});
+
+	// CSS Color 4 makes rgb()/rgba() exact aliases, so the 3-arg legacy `rgb(...)`
+	// form also accepts a 4th alpha value: rgb(255, 0, 0, 0.5)
+	it("RgbFunctionAlphaString validates legacy rgb() with a 4th alpha value", () => {
+		expectTypeOf<
+			RgbFunctionAlphaString<"rgb(255, 0, 0, 0.5)">
+		>().toEqualTypeOf<"rgb(255, 0, 0, 0.5)">();
+		expectTypeOf<RgbFunctionAlphaString<"rgb(255,0,0,0.5)">>().toEqualTypeOf<"rgb(255,0,0,0.5)">();
+		expectTypeOf<
+			RgbFunctionAlphaString<"rgb(100%, 0%, 0%, 50%)">
+		>().toEqualTypeOf<"rgb(100%, 0%, 0%, 50%)">();
+		expectTypeOf<RgbFunctionAlphaString<"rgb(255, 0, 0)">>().toEqualTypeOf<never>();
+		expectTypeOf<RgbFunctionAlphaString<"rgba(255, 0, 0, 0.5)">>().toEqualTypeOf<never>();
+	});
+
+	it("RgbString accepts legacy rgb() with a 4th alpha value, but rgba() 3-arg alias remains rejected", () => {
+		expectTypeOf<RgbString<"rgb(255, 0, 0, 0.5)">>().toEqualTypeOf<"rgb(255, 0, 0, 0.5)">();
+
+		// 3-arg rgba() without alpha is intentionally deferred/out of scope, not accepted here
+		expectTypeOf<RgbaFunctionString<"rgba(255, 0, 0)">>().toEqualTypeOf<never>();
+		expectTypeOf<RgbString<"rgba(255, 0, 0)">>().toEqualTypeOf<never>();
 	});
 });

--- a/packages/use-color/src/types/Rgb.ts
+++ b/packages/use-color/src/types/Rgb.ts
@@ -15,6 +15,13 @@ export type RgbFunctionString<T extends string> =
 		? T
 		: never;
 
+// CSS Color 4 makes rgb()/rgba() exact aliases, so the 3-arg legacy `rgb(...)` form
+// also accepts a 4th alpha value: rgb(255, 0, 0, 0.5)
+export type RgbFunctionAlphaString<T extends string> =
+	T extends `rgb(${ColorValue},${OptionalSpace}${ColorValue},${OptionalSpace}${ColorValue},${OptionalSpace}${AlphaValue})`
+		? T
+		: never;
+
 export type RgbaFunctionString<T extends string> =
 	T extends `rgba(${ColorValue},${OptionalSpace}${ColorValue},${OptionalSpace}${ColorValue},${OptionalSpace}${AlphaValue})`
 		? T
@@ -29,6 +36,7 @@ export type RgbModernString<T extends string> =
 
 export type RgbString<T extends string> =
 	| RgbFunctionString<T>
+	| RgbFunctionAlphaString<T>
 	| RgbaFunctionString<T>
 	| RgbModernString<T>;
 

--- a/packages/use-color/src/types/__tests__/Hsl.test-d.ts
+++ b/packages/use-color/src/types/__tests__/Hsl.test-d.ts
@@ -4,6 +4,7 @@ import type {
 	HslaLegacyString,
 	HslaString,
 	HslInputString,
+	HslLegacyAlphaString,
 	HslLegacyString,
 	HslModernAlphaString,
 	HslModernString,
@@ -91,5 +92,31 @@ describe("Hsl types", () => {
 		expectTypeOf<HslInputString<"hsl(0, 0%, 0%)">>().toEqualTypeOf<"hsl(0, 0%, 0%)">();
 		expectTypeOf<HslInputString<"hsl(360, 100%, 100%)">>().toEqualTypeOf<"hsl(360, 100%, 100%)">();
 		expectTypeOf<HslInputString<"hsl(0 0% 0%)">>().toEqualTypeOf<"hsl(0 0% 0%)">();
+	});
+
+	// CSS Color 4 makes hsl()/hsla() exact aliases, so the 3-arg legacy `hsl(...)`
+	// form also accepts a 4th alpha value: hsl(120, 50%, 50%, 0.5)
+	it("HslLegacyAlphaString validates legacy hsl() with a 4th alpha value", () => {
+		expectTypeOf<
+			HslLegacyAlphaString<"hsl(120, 50%, 50%, 0.5)">
+		>().toEqualTypeOf<"hsl(120, 50%, 50%, 0.5)">();
+		expectTypeOf<
+			HslLegacyAlphaString<"hsl(120,50%,50%,0.5)">
+		>().toEqualTypeOf<"hsl(120,50%,50%,0.5)">();
+		expectTypeOf<
+			HslLegacyAlphaString<"hsl(120, 50%, 50%, 50%)">
+		>().toEqualTypeOf<"hsl(120, 50%, 50%, 50%)">();
+		expectTypeOf<HslLegacyAlphaString<"hsl(120, 50%, 50%)">>().toEqualTypeOf<never>();
+		expectTypeOf<HslLegacyAlphaString<"hsla(120, 50%, 50%, 0.5)">>().toEqualTypeOf<never>();
+	});
+
+	it("HslInputString accepts legacy hsl() with a 4th alpha value, but hsla() 3-arg alias remains rejected", () => {
+		expectTypeOf<
+			HslInputString<"hsl(120, 50%, 50%, 0.5)">
+		>().toEqualTypeOf<"hsl(120, 50%, 50%, 0.5)">();
+
+		// 3-arg hsla() without alpha is intentionally deferred/out of scope, not accepted here
+		expectTypeOf<HslaLegacyString<"hsla(180, 50%, 50%)">>().toEqualTypeOf<never>();
+		expectTypeOf<HslInputString<"hsla(180, 50%, 50%)">>().toEqualTypeOf<never>();
 	});
 });

--- a/packages/use-color/src/types/__tests__/oklch.test-d.ts
+++ b/packages/use-color/src/types/__tests__/oklch.test-d.ts
@@ -182,6 +182,33 @@ describe("Oklch types", () => {
 		expectTypeOf<OklchInputString<"oklch(100% 0.2 180)">>().toEqualTypeOf<"oklch(100% 0.2 180)">();
 	});
 
+	// 1.11: the runtime OKLCH parser accepts a negative hue and normalizes it
+	// into [0, 360), so the type layer must accept negative hue strings too
+	// (the `${number}` template already permits a leading "-", this just
+	// proves it isn't accidentally narrowed anywhere in the OKLCH types).
+	it("OklchString and OklchInputString accept a negative hue", () => {
+		expectTypeOf<OklchString<"oklch(0.5 0.2 -90)">>().toEqualTypeOf<"oklch(0.5 0.2 -90)">();
+		expectTypeOf<OklchInputString<"oklch(0.5 0.2 -90)">>().toEqualTypeOf<"oklch(0.5 0.2 -90)">();
+		expectTypeOf<
+			OklchInputString<"oklch(0.5 0.2 -90 / 0.5)">
+		>().toEqualTypeOf<"oklch(0.5 0.2 -90 / 0.5)">();
+	});
+
+	// 1.12: the runtime parser clamps L to [0, 1] and C to [0, Infinity) at
+	// parse time, but the type layer only validates grammar (not numeric
+	// range), so out-of-range and negative L/C strings still type-check —
+	// clamping is a runtime concern, not a compile-time rejection.
+	it("OklchString and OklchInputString accept out-of-range L and C values", () => {
+		expectTypeOf<OklchString<"oklch(1.5 0.2 180)">>().toEqualTypeOf<"oklch(1.5 0.2 180)">();
+		expectTypeOf<OklchString<"oklch(-0.2 0.2 180)">>().toEqualTypeOf<"oklch(-0.2 0.2 180)">();
+		expectTypeOf<OklchString<"oklch(0.5 -0.2 180)">>().toEqualTypeOf<"oklch(0.5 -0.2 180)">();
+		expectTypeOf<OklchString<"oklch(0.5 1.5 180)">>().toEqualTypeOf<"oklch(0.5 1.5 180)">();
+		expectTypeOf<OklchInputString<"oklch(1.5 0.2 180)">>().toEqualTypeOf<"oklch(1.5 0.2 180)">();
+		expectTypeOf<
+			OklchInputString<"oklch(-0.2 -0.2 180)">
+		>().toEqualTypeOf<"oklch(-0.2 -0.2 180)">();
+	});
+
 	it("OklchInputString validates various alpha formats with different slash spacing", () => {
 		expectTypeOf<
 			OklchInputString<"oklch(0.5 0.2 180/1)">

--- a/packages/use-color/src/types/index.ts
+++ b/packages/use-color/src/types/index.ts
@@ -25,6 +25,7 @@ export type {
 	HslaLegacyString,
 	HslaString,
 	HslInputString,
+	HslLegacyAlphaString,
 	HslLegacyString,
 	HslModernAlphaString,
 	HslModernString,


### PR DESCRIPTION
## P1-C — parsers (audit items 1.10–1.15)

> Stacked on #15 — diff shown against `fix/p1b-ops-a11y`.

The library's core invariant is **type/runtime grammar parity** — template-literal types and runtime regexes must accept exactly the same strings. Every change here lands types + runtime together, with `.test-d.ts` cases proving both directions.

1. **1.10** `rgb(255, 0, 0, 0.5)` (valid CSS — rgb/rgba are aliases) silently parsed as **opaque** red: the `([^)]+)` capture swallowed `, 0.5`. Now: alpha preserved (`a: 0.5`), out-of-range alpha clamps to [0,1] per CSS, garbage like `rgb(1.2.3, 0, 0)` rejected. `RgbInputString` accepts the same form.
2. **1.11** `oklch(0.5 0.2 -90)` was **accepted by the type layer but threw at runtime** — a direct violation of the parity invariant on the flagship space. Now parses and normalizes to `h: 270`.
3. **1.12** OKLCH ranges: `L > 1` was accepted verbatim, negative L/C rejected. Now clamps L to [0,1], C to [0,∞) per CSS.
4. **1.13** `hsl(120, 50%, 50%, 0.5)` accepted (CSS alias rule). `hsla()` 3-arg stays rejected — that expansion was adversarially refuted as intentional CSS-subset design.
5. **1.14** One shared strict number token (`src/parse/number.ts`) in all parsers: multi-dot numbers no longer silently truncate via `parseFloat`, scientific notation handled uniformly.
6. **1.15** Hex alpha stored as exact `alphaByte/255` — `parseHex → toHex8` is now identity for **all 256 alpha bytes** (test iterates every byte; independently re-verified via the public API).

### Verification
`pnpm typecheck && pnpm test && pnpm build && pnpm lint` ✅ — **1932/1932** (39 new tests incl. test-d parity cases), lint steady at 31.

---
Ultracode audit fix series (PR 4/10).