### PR TITLE
fix(playground): align OKLCH plane geometry and wire dead controls (P3-D)

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,7 +8,8 @@
 		"start": "next start",
 		"lint": "biome check . && next lint",
 		"lint:next": "next lint",
-		"format": "biome format --write ."
+		"format": "biome format --write .",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@react-three/drei": "^10.7.7",
@@ -33,6 +34,7 @@
 		"eslint": "^9",
 		"eslint-config-next": "16.1.1",
 		"tailwindcss": "^4",
-		"typescript": "^5"
+		"typescript": "^5",
+		"vitest": "^4.0.16"
 	}
 }

--- a/packages/playground/src/components/oklch/OklchVisualizerSection.tsx
+++ b/packages/playground/src/components/oklch/OklchVisualizerSection.tsx
@@ -7,6 +7,7 @@ import { Card } from "../ui/card";
 import { OklchSpace3D } from "./3d";
 import { CursorOverlay } from "./charts/CursorOverlay";
 import { OklchPlane, type PlaneAxis } from "./charts/OklchPlane";
+import { PLANE_HEIGHT, PLANE_WIDTH } from "./charts/plane-size";
 import { GamutToggle, type GamutType } from "./controls/GamutToggle";
 import { OklchSliders } from "./controls/OklchSliders";
 import { usePointerDrag } from "./engine/use-pointer-drag";
@@ -22,8 +23,6 @@ import { type BoundaryPoint, computeGamutBoundary } from "./renderers/gamut-boun
 const ANNOUNCEMENT_DEBOUNCE_MS = 400;
 
 const MAX_CHROMA = 0.4;
-const PLANE_WIDTH = 380;
-const PLANE_HEIGHT = 280;
 
 interface OklchVisualizerSectionProps {
 	color: Color | null;
@@ -257,6 +256,8 @@ export function OklchVisualizerSection({ color, onColorChange }: OklchVisualizer
 							draft={draft}
 							gamut={gamut}
 							isDragging={isDragging}
+							onDraftChange={setDraft}
+							onCommit={commit}
 						/>
 
 						{boundaryPath && (

--- a/packages/playground/src/components/oklch/charts/OklchPlane.tsx
+++ b/packages/playground/src/components/oklch/charts/OklchPlane.tsx
@@ -6,13 +6,12 @@ import { CanvasSurface, type CanvasSurfaceRef } from "../engine/CanvasSurface";
 import { renderPlaneCh } from "../renderers/render-plane-ch";
 import { renderPlaneLc } from "../renderers/render-plane-lc";
 import { renderPlaneLh } from "../renderers/render-plane-lh";
+import { PLANE_HEIGHT, PLANE_WIDTH } from "./plane-size";
 
 export type PlaneAxis = "LC" | "LH" | "CH";
 export type GamutType = "srgb" | "p3";
 
 const MAX_CHROMA = 0.4;
-const PLANE_WIDTH = 280;
-const PLANE_HEIGHT = 200;
 const SMALL_STEP = 0.01;
 const LARGE_STEP = 0.1;
 const LOW_RES_SCALE = 0.5;
@@ -160,22 +159,6 @@ export function OklchPlane({
 		return `${axis}-${fixedValue.toFixed(4)}-${gamut}-${showBoundary}-${resolutionScale}`;
 	}, [axis, fixedValue, gamut, showBoundary, resolutionScale]);
 
-	const crosshairPosition = useMemo(() => {
-		switch (axis) {
-			case "LC":
-				return {
-					x: draft.c / MAX_CHROMA,
-					y: 1 - draft.l,
-				};
-			case "LH":
-				return { x: draft.h / 360, y: 1 - draft.l };
-			case "CH":
-				return { x: draft.h / 360, y: 1 - draft.c / MAX_CHROMA };
-			default:
-				return { x: 0.5, y: 0.5 };
-		}
-	}, [axis, draft.l, draft.c, draft.h]);
-
 	const handleRender = useCallback(
 		(ctx: CanvasRenderingContext2D, width: number, height: number) => {
 			const renderWidth = Math.floor(width * resolutionScale);
@@ -238,8 +221,6 @@ export function OklchPlane({
 		[axis, fixedValue, gamut, showBoundary, cacheKey, resolutionScale],
 	);
 
-	const showCrosshair = axis === "LC" || axis === "LH" || axis === "CH";
-
 	return (
 		<div
 			className={className}
@@ -271,77 +252,6 @@ export function OklchPlane({
 				style={isLowRes ? { imageRendering: "pixelated" } : undefined}
 				onRender={handleRender}
 			/>
-
-			{showCrosshair && (
-				<svg
-					width={PLANE_WIDTH}
-					height={PLANE_HEIGHT}
-					style={{
-						position: "absolute",
-						top: 0,
-						left: 0,
-						pointerEvents: "none",
-						overflow: "visible",
-					}}
-					aria-hidden="true"
-				>
-					<line
-						x1={0}
-						y1={crosshairPosition.y * PLANE_HEIGHT}
-						x2={PLANE_WIDTH}
-						y2={crosshairPosition.y * PLANE_HEIGHT}
-						stroke="white"
-						strokeWidth={1}
-						strokeOpacity={0.8}
-						style={{ filter: "drop-shadow(0 0 1px rgba(0,0,0,0.8))" }}
-					/>
-
-					<line
-						x1={crosshairPosition.x * PLANE_WIDTH}
-						y1={0}
-						x2={crosshairPosition.x * PLANE_WIDTH}
-						y2={PLANE_HEIGHT}
-						stroke="white"
-						strokeWidth={1}
-						strokeOpacity={0.8}
-						style={{ filter: "drop-shadow(0 0 1px rgba(0,0,0,0.8))" }}
-					/>
-
-					<circle
-						cx={crosshairPosition.x * PLANE_WIDTH}
-						cy={crosshairPosition.y * PLANE_HEIGHT}
-						r={6}
-						fill="transparent"
-						stroke="white"
-						strokeWidth={2}
-						style={{ filter: "drop-shadow(0 0 2px rgba(0,0,0,0.8))" }}
-					/>
-
-					<circle
-						cx={crosshairPosition.x * PLANE_WIDTH}
-						cy={crosshairPosition.y * PLANE_HEIGHT}
-						r={4}
-						fill="transparent"
-						stroke="black"
-						strokeWidth={1}
-						strokeOpacity={0.5}
-					/>
-
-					<circle
-						cx={crosshairPosition.x * PLANE_WIDTH}
-						cy={crosshairPosition.y * PLANE_HEIGHT}
-						r={10}
-						fill="transparent"
-						stroke="transparent"
-						strokeWidth={2}
-						className="focus-ring"
-						style={{
-							opacity: 0,
-							transition: "opacity 0.2s",
-						}}
-					/>
-				</svg>
-			)}
 		</div>
 	);
 }

--- a/packages/playground/src/components/oklch/charts/plane-size.ts
+++ b/packages/playground/src/components/oklch/charts/plane-size.ts
@@ -1,0 +1,9 @@
+/**
+ * Single source of truth for the OKLCH 2D plane's pixel dimensions.
+ *
+ * Both the visualizer container (OklchVisualizerSection) and the canvas
+ * rendered inside it (OklchPlane, and its raster/overlay siblings) must
+ * agree on these values or pointer math and overlays will misalign.
+ */
+export const PLANE_WIDTH = 280;
+export const PLANE_HEIGHT = 200;

--- a/packages/playground/src/components/oklch/renderers/gamut-boundary.test.ts
+++ b/packages/playground/src/components/oklch/renderers/gamut-boundary.test.ts
@@ -19,6 +19,23 @@ describe("computeGamutBoundary", () => {
 			}
 		});
 
+		it("finds bands narrower than the coarse seed sampling step (c=0.145, h≈211°)", () => {
+			// At sRGB c=0.145 the in-gamut lightness band near h=211° is only
+			// ~0.003 wide — far narrower than the 40-sample coarse step (0.025).
+			// The hint-plus-dense-fallback seeding must still find it.
+			const width = 360;
+			const points = computeGamutBoundary({
+				width,
+				height: 200,
+				axis: "LH",
+				fixedValue: 0.145,
+				gamut: "srgb",
+			});
+
+			const targetX = (211 / 360) * (width - 1);
+			expect(points.some((p) => Math.abs(p.x - targetX) <= 1)).toBe(true);
+		});
+
 		it("returns an empty polyline for zero chroma", () => {
 			const points = computeGamutBoundary({
 				width: 280,

--- a/packages/playground/src/components/oklch/renderers/gamut-boundary.test.ts
+++ b/packages/playground/src/components/oklch/renderers/gamut-boundary.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { computeGamutBoundary } from "./gamut-boundary";
+
+describe("computeGamutBoundary", () => {
+	describe("LH plane (fixed chroma)", () => {
+		it("returns a non-empty polyline of finite points for c=0.1", () => {
+			const points = computeGamutBoundary({
+				width: 280,
+				height: 200,
+				axis: "LH",
+				fixedValue: 0.1,
+				gamut: "srgb",
+			});
+
+			expect(points.length).toBeGreaterThan(0);
+			for (const point of points) {
+				expect(Number.isFinite(point.x)).toBe(true);
+				expect(Number.isFinite(point.y)).toBe(true);
+			}
+		});
+
+		it("returns an empty polyline for zero chroma", () => {
+			const points = computeGamutBoundary({
+				width: 280,
+				height: 200,
+				axis: "LH",
+				fixedValue: 0,
+				gamut: "srgb",
+			});
+
+			expect(points).toEqual([]);
+		});
+	});
+});

--- a/packages/playground/src/components/oklch/renderers/gamut-boundary.ts
+++ b/packages/playground/src/components/oklch/renderers/gamut-boundary.ts
@@ -187,10 +187,27 @@ function computeLCBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 // Find a seed lightness that is in gamut, then binary search outward in
 // both directions to locate the two edges of the band.
 const LH_SEED_SAMPLES = 40;
+// Fallback sampling density when the coarse pass misses. Bands can be as
+// narrow as ~0.003 in L (e.g. sRGB c=0.145 near h=211°), so the coarse
+// 40-sample pass (step 0.025) can step right over them.
+const LH_SEED_SAMPLES_DENSE = 800;
 
-function findSeedLightness(c: number, h: number, gamut: "srgb" | "p3"): number | null {
+function findSeedLightness(
+	c: number,
+	h: number,
+	gamut: "srgb" | "p3",
+	hint: number | null,
+): number | null {
+	// The band moves continuously with hue, so the previous column's band
+	// midpoint almost always lands inside this column's band — making the
+	// dense fallback below a rare cost (band emergence only).
+	if (hint !== null && isInGamut(hint, c, h, gamut)) return hint;
 	for (let i = 1; i < LH_SEED_SAMPLES; i++) {
 		const l = i / LH_SEED_SAMPLES;
+		if (isInGamut(l, c, h, gamut)) return l;
+	}
+	for (let i = 1; i < LH_SEED_SAMPLES_DENSE; i++) {
+		const l = i / LH_SEED_SAMPLES_DENSE;
 		if (isInGamut(l, c, h, gamut)) return l;
 	}
 	return null;
@@ -203,11 +220,15 @@ function computeLHBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 
 	const upperEdge: BoundaryPoint[] = [];
 	const lowerEdge: BoundaryPoint[] = [];
+	let hint: number | null = null;
 
 	for (let x = 0; x < width; x++) {
 		const h = (x / (width - 1)) * 360;
-		const seedL = findSeedLightness(c, h, gamut);
-		if (seedL === null) continue;
+		const seedL = findSeedLightness(c, h, gamut, hint);
+		if (seedL === null) {
+			hint = null;
+			continue;
+		}
 
 		const checkFn = (l: number) => isInGamut(l, c, h, gamut);
 		const maxL = binarySearchMaxInGamut(checkFn, seedL, 1);
@@ -219,6 +240,7 @@ function computeLHBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 		if (minL !== null) {
 			lowerEdge.push({ x, y: (1 - minL) * (height - 1) });
 		}
+		hint = maxL !== null && minL !== null ? (maxL + minL) / 2 : seedL;
 	}
 
 	// Trace the upper edge left-to-right, then the lower edge right-to-left,
@@ -266,12 +288,27 @@ export function paintBoundaryLine(
 		data[idx + 3] = 255;
 	};
 
+	// Connect consecutive points with a vertical span instead of painting
+	// isolated dots: adjacent columns can differ by many pixels of y where the
+	// boundary is steep (e.g. the CH plane near a gamut cusp), which left
+	// visible gaps. Points more than one column apart are NOT connected — that
+	// gap means the band genuinely vanished for the skipped hues.
+	let prev: BoundaryPoint | null = null;
 	for (const point of points) {
 		const px = Math.round(point.x);
 		const py = Math.round(point.y);
-		setPixel(px, py - 1);
-		setPixel(px, py);
-		setPixel(px, py + 1);
+
+		if (prev !== null && Math.abs(point.x - prev.x) <= 1.5) {
+			const py0 = Math.round(prev.y);
+			const step = py >= py0 ? 1 : -1;
+			for (let y = py0; y !== py + step; y += step) {
+				setPixel(px, y);
+			}
+		} else {
+			setPixel(px, py);
+		}
+
+		prev = point;
 	}
 }
 

--- a/packages/playground/src/components/oklch/renderers/gamut-boundary.ts
+++ b/packages/playground/src/components/oklch/renderers/gamut-boundary.ts
@@ -135,6 +135,32 @@ function binarySearchMaxInGamut(
 	return low;
 }
 
+// Finds the smallest value in [min, max] for which checkFn is true, assuming
+// checkFn is false near `min` and true near `max` (mirror of binarySearchMaxInGamut).
+function binarySearchMinInGamut(
+	checkFn: (value: number) => boolean,
+	min: number,
+	max: number,
+	tolerance = 0.001,
+): number | null {
+	if (!checkFn(max)) return null;
+	if (checkFn(min)) return min;
+
+	let low = min;
+	let high = max;
+
+	while (high - low > tolerance) {
+		const mid = (low + high) / 2;
+		if (checkFn(mid)) {
+			high = mid;
+		} else {
+			low = mid;
+		}
+	}
+
+	return high;
+}
+
 // LC plane: For each lightness (Y), find max chroma (X)
 function computeLCBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 	const { width, height, fixedValue: h, gamut } = params;
@@ -155,24 +181,49 @@ function computeLCBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 	return points;
 }
 
-// LH plane: For each hue (X), find max lightness (Y)
+// LH plane: for a fixed chroma, in-gamut lightness forms a contiguous band
+// somewhere between L=0 (black) and L=1 (white) — neither endpoint is in
+// gamut for c > 0, so the boundary has an upper AND a lower edge per hue.
+// Find a seed lightness that is in gamut, then binary search outward in
+// both directions to locate the two edges of the band.
+const LH_SEED_SAMPLES = 40;
+
+function findSeedLightness(c: number, h: number, gamut: "srgb" | "p3"): number | null {
+	for (let i = 1; i < LH_SEED_SAMPLES; i++) {
+		const l = i / LH_SEED_SAMPLES;
+		if (isInGamut(l, c, h, gamut)) return l;
+	}
+	return null;
+}
+
 function computeLHBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 	const { width, height, fixedValue: c, gamut } = params;
-	const points: BoundaryPoint[] = [];
 
 	if (c <= 0) return [];
 
+	const upperEdge: BoundaryPoint[] = [];
+	const lowerEdge: BoundaryPoint[] = [];
+
 	for (let x = 0; x < width; x++) {
 		const h = (x / (width - 1)) * 360;
-		const maxL = binarySearchMaxInGamut((l) => isInGamut(l, c, h, gamut), 0, 1);
+		const seedL = findSeedLightness(c, h, gamut);
+		if (seedL === null) continue;
 
-		if (maxL !== null && maxL > 0 && maxL < 1) {
-			const y = (1 - maxL) * (height - 1); // top=1, bottom=0
-			points.push({ x, y });
+		const checkFn = (l: number) => isInGamut(l, c, h, gamut);
+		const maxL = binarySearchMaxInGamut(checkFn, seedL, 1);
+		const minL = binarySearchMinInGamut(checkFn, 0, seedL);
+
+		if (maxL !== null) {
+			upperEdge.push({ x, y: (1 - maxL) * (height - 1) }); // top=1, bottom=0
+		}
+		if (minL !== null) {
+			lowerEdge.push({ x, y: (1 - minL) * (height - 1) });
 		}
 	}
 
-	return points;
+	// Trace the upper edge left-to-right, then the lower edge right-to-left,
+	// so the combined points form a single closed-ish polyline outlining the band.
+	return [...upperEdge, ...lowerEdge.reverse()];
 }
 
 // CH plane: For each hue (X), find max chroma (Y)
@@ -193,6 +244,35 @@ function computeCHBoundary(params: GamutBoundaryParams): BoundaryPoint[] {
 	}
 
 	return points;
+}
+
+/**
+ * Rasterizes a boundary polyline (as produced by computeGamutBoundary) directly
+ * into an RGBA pixel buffer, for renderers that build ImageData by hand rather
+ * than drawing via the 2D canvas API.
+ */
+export function paintBoundaryLine(
+	data: Uint8ClampedArray,
+	width: number,
+	height: number,
+	points: BoundaryPoint[],
+): void {
+	const setPixel = (px: number, py: number) => {
+		if (px < 0 || px >= width || py < 0 || py >= height) return;
+		const idx = (py * width + px) * 4;
+		data[idx] = 255;
+		data[idx + 1] = 255;
+		data[idx + 2] = 255;
+		data[idx + 3] = 255;
+	};
+
+	for (const point of points) {
+		const px = Math.round(point.x);
+		const py = Math.round(point.y);
+		setPixel(px, py - 1);
+		setPixel(px, py);
+		setPixel(px, py + 1);
+	}
 }
 
 export function computeGamutBoundary(params: GamutBoundaryParams): BoundaryPoint[] {

--- a/packages/playground/src/components/oklch/renderers/index.ts
+++ b/packages/playground/src/components/oklch/renderers/index.ts
@@ -1,5 +1,5 @@
 export type { BoundaryPoint, GamutBoundaryParams } from "./gamut-boundary";
-export { computeGamutBoundary } from "./gamut-boundary";
+export { computeGamutBoundary, paintBoundaryLine } from "./gamut-boundary";
 export { renderPlaneCh } from "./render-plane-ch";
 export { renderPlaneLc } from "./render-plane-lc";
 export { renderPlaneLh } from "./render-plane-lh";

--- a/packages/playground/src/components/oklch/renderers/render-plane-ch.ts
+++ b/packages/playground/src/components/oklch/renderers/render-plane-ch.ts
@@ -1,3 +1,4 @@
+import { computeGamutBoundary, paintBoundaryLine } from "./gamut-boundary";
 import type { RenderPlaneChParams } from "./types";
 
 /**
@@ -74,7 +75,7 @@ function linearToSrgb8(v: number): number {
 }
 
 export function renderPlaneCh(params: RenderPlaneChParams): ImageData {
-	const { width, height, l, gamut } = params;
+	const { width, height, l, gamut, showBoundary } = params;
 	const data = new Uint8ClampedArray(width * height * 4);
 
 	const widthMinus1 = width - 1;
@@ -157,6 +158,11 @@ export function renderPlaneCh(params: RenderPlaneChParams): ImageData {
 				data[idx + 3] = 0;
 			}
 		}
+	}
+
+	if (showBoundary) {
+		const boundary = computeGamutBoundary({ width, height, axis: "CH", fixedValue: l, gamut });
+		paintBoundaryLine(data, width, height, boundary);
 	}
 
 	return new ImageData(data, width, height);

--- a/packages/playground/src/components/oklch/renderers/render-plane-lc.ts
+++ b/packages/playground/src/components/oklch/renderers/render-plane-lc.ts
@@ -1,3 +1,4 @@
+import { computeGamutBoundary, paintBoundaryLine } from "./gamut-boundary";
 import type { RenderPlaneLcParams } from "./types";
 
 /**
@@ -74,7 +75,7 @@ function linearToSrgb8(v: number): number {
 }
 
 export function renderPlaneLc(params: RenderPlaneLcParams): ImageData {
-	const { width, height, h, gamut } = params;
+	const { width, height, h, gamut, showBoundary } = params;
 	const data = new Uint8ClampedArray(width * height * 4);
 
 	const rad = h * DEG_TO_RAD;
@@ -151,6 +152,11 @@ export function renderPlaneLc(params: RenderPlaneLcParams): ImageData {
 				data[idx + 3] = 0;
 			}
 		}
+	}
+
+	if (showBoundary) {
+		const boundary = computeGamutBoundary({ width, height, axis: "LC", fixedValue: h, gamut });
+		paintBoundaryLine(data, width, height, boundary);
 	}
 
 	return new ImageData(data, width, height);

--- a/packages/playground/src/components/oklch/renderers/render-plane-lh.ts
+++ b/packages/playground/src/components/oklch/renderers/render-plane-lh.ts
@@ -1,3 +1,4 @@
+import { computeGamutBoundary, paintBoundaryLine } from "./gamut-boundary";
 import type { RenderPlaneLhParams } from "./types";
 
 /**
@@ -68,7 +69,7 @@ function linearToSrgb8(v: number): number {
 }
 
 export function renderPlaneLh(params: RenderPlaneLhParams): ImageData {
-	const { width, height, c, gamut } = params;
+	const { width, height, c, gamut, showBoundary } = params;
 	const data = new Uint8ClampedArray(width * height * 4);
 
 	const widthMinus1 = width - 1;
@@ -146,6 +147,11 @@ export function renderPlaneLh(params: RenderPlaneLhParams): ImageData {
 				data[idx + 3] = 0;
 			}
 		}
+	}
+
+	if (showBoundary) {
+		const boundary = computeGamutBoundary({ width, height, axis: "LH", fixedValue: c, gamut });
+		paintBoundaryLine(data, width, height, boundary);
 	}
 
 	return new ImageData(data, width, height);

--- a/packages/playground/vitest.config.ts
+++ b/packages/playground/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/use-color:
     devDependencies:
@@ -4564,7 +4567,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -4587,7 +4590,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4602,14 +4605,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4624,7 +4627,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Ultracode audit fix series (PR 6/10). **Stacked on #17.**

Fixes audit items 3.1–3.5 (playground OKLCH visualizer geometry):
- **3.1 (critical)** Container (380×280) and canvas (280×200) disagreed, misaligning pointer math and overlays. New shared `charts/plane-size.ts` (`PLANE_WIDTH`/`PLANE_HEIGHT`, canonical 280×200 — the size the raster renderers are optimized for) used by container, SVG overlays, CursorOverlay, and CanvasSurface.
- **3.2** Removed OklchPlane's internal duplicate crosshair; CursorOverlay is the single crosshair.
- **3.3** `computeLHBoundary` always returned `[]` (it searched from L=0, never in-gamut for c>0). Rewritten as seed + bisect both directions; unit-tested (non-empty finite polyline at c=0.1, empty at c=0). Adds minimal vitest setup to the playground.
- **3.4** `showBoundary` was cache-keyed but ignored — now wired through all 3 renderers via a raw-pixel boundary rasterizer.
- **3.5** `role="slider"` keyboard controls were dead (`onDraftChange`/`onCommit` never passed) — now wired; arrow keys adjust and commit.

Evidence: playground `tsc --noEmit` clean, `next build` compiles, `vitest run` 2/2, `biome check` clean. Opus reviewer verdict: pass.