### PR TITLE
fix(playground): correct feature-panel color science (P3-F)

### DIFF
--- a/packages/playground/src/components/analysis.tsx
+++ b/packages/playground/src/components/analysis.tsx
@@ -9,6 +9,7 @@ import {
 	isInGamut,
 	isInP3Gamut,
 	luminance,
+	WCAG_THRESHOLDS,
 } from "use-color";
 import { Card } from "./ui/card";
 
@@ -40,7 +41,12 @@ export function Analysis({ color, inputValue }: AnalysisProps) {
 	const apcaLc = Math.round(
 		Math.abs(apcaContrast(color.toRgb(), { r: 255, g: 255, b: 255, a: 1 })),
 	);
-	const isWCAGAA = contrastWhite >= 4.5 || contrastBlack >= 4.5;
+	// WCAG 2.x AA: judge the best achievable contrast (color paired with white or
+	// black) against 4.5:1 for normal text and 3:1 for large text (>=18pt, or
+	// >=14pt bold). WCAG_THRESHOLDS.AA = 4.5, WCAG_THRESHOLDS.AA_LARGE = 3.
+	const bestContrast = Math.max(contrastWhite, contrastBlack);
+	const isWCAGAANormal = bestContrast >= WCAG_THRESHOLDS.AA;
+	const isWCAGAALarge = bestContrast >= WCAG_THRESHOLDS.AA_LARGE;
 	const inSRgb = isInGamut(color.toOklch());
 	const inP3 = isInP3Gamut(color.toOklch());
 
@@ -87,10 +93,18 @@ export function Analysis({ color, inputValue }: AnalysisProps) {
 				<DataRow
 					label="WCAG AA"
 					value={
-						<div className="flex items-center gap-1">
-							<StatusIcon valid={isWCAGAA} />
-							<span className={isWCAGAA ? "text-[var(--success)]" : "text-[var(--error)]"}>
-								{isWCAGAA ? "Pass" : "Fail"}
+						<div className="flex items-center gap-3">
+							<span className="flex items-center gap-1">
+								<StatusIcon valid={isWCAGAANormal} />
+								<span className={isWCAGAANormal ? "text-[var(--success)]" : "text-[var(--error)]"}>
+									Normal
+								</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<StatusIcon valid={isWCAGAALarge} />
+								<span className={isWCAGAALarge ? "text-[var(--success)]" : "text-[var(--error)]"}>
+									Large
+								</span>
 							</span>
 						</div>
 					}

--- a/packages/playground/src/components/oklch/OklchVisualizerSection.tsx
+++ b/packages/playground/src/components/oklch/OklchVisualizerSection.tsx
@@ -65,8 +65,10 @@ export function OklchVisualizerSection({ color, onColorChange }: OklchVisualizer
 
 	const { draft, setDraft, previewColor, commit, reset, isDirty } = useOklchDraft(color, {
 		onCommit: (newColor) => {
-			const alpha = newColor.getAlpha();
-			onColorChange(alpha < 1 ? newColor.toHex8() : newColor.toHex());
+			// Commit the OKLCH string (color() parses it) rather than converting to
+			// sRGB hex, which would gamut-crush wide-gamut colors and discard the
+			// OKLCH precision the user just dialed in. toOklchString() keeps alpha.
+			onColorChange(newColor.toOklchString());
 			setAnnouncement(`Color applied: ${formatAnnouncement(draft.l, draft.c, draft.h)}`);
 		},
 	});

--- a/packages/playground/src/components/oklch/features/APCAVisualization.tsx
+++ b/packages/playground/src/components/oklch/features/APCAVisualization.tsx
@@ -1,24 +1,31 @@
 "use client";
 
 import { useMemo } from "react";
-import { apcaContrast, type Color, color } from "use-color";
+import { APCA_THRESHOLDS, apcaContrast, type Color, color } from "use-color";
 
 export interface APCAVisualizationProps {
 	color: Color;
 }
 
 /**
- * APCA Lc value thresholds for different use cases.
- * APCA is font-size dependent; these are simplified guidelines.
- * @see https://www.myndex.com/APCA/ for detailed font-size charts
+ * APCA "bronze" Lc pass tiers (|Lc| >= 90 / 75 / 60 / 45 / 30 / 15). APCA is
+ * font-size dependent; these are the simplified general guidelines.
+ *
+ * The 90/75/60/45/30 thresholds are sourced from the use-color library's
+ * APCA_THRESHOLDS (PREFERRED_BODY / BODY_TEXT / LARGE_TEXT / HEADLINE /
+ * NON_TEXT). The lowest tier (15, spot/decorative) is not part of
+ * APCA_THRESHOLDS, so it is defined locally.
+ * @see https://www.myndex.com/APCA/ for the font-size-vs-Lc lookup tables
  */
+const APCA_MIN_DECORATIVE = 15;
+
 const APCA_LEVELS = [
-	{ min: 90, label: "Fluent Text", size: "12px+" },
-	{ min: 75, label: "Body Text", size: "14px+" },
-	{ min: 60, label: "Large Text", size: "18px+" },
-	{ min: 45, label: "Headlines", size: "24px+" },
-	{ min: 30, label: "Large Headlines", size: "36px+" },
-	{ min: 15, label: "Non-text/Decoration", size: "N/A" },
+	{ min: APCA_THRESHOLDS.PREFERRED_BODY, label: "Fluent Text", size: "12px+" },
+	{ min: APCA_THRESHOLDS.BODY_TEXT, label: "Body Text", size: "14px+" },
+	{ min: APCA_THRESHOLDS.LARGE_TEXT, label: "Large Text", size: "18px+" },
+	{ min: APCA_THRESHOLDS.HEADLINE, label: "Headlines", size: "24px+" },
+	{ min: APCA_THRESHOLDS.NON_TEXT, label: "Large Headlines", size: "36px+" },
+	{ min: APCA_MIN_DECORATIVE, label: "Non-text/Decoration", size: "N/A" },
 ] as const;
 
 export function APCAVisualization({ color: inputColor }: APCAVisualizationProps) {

--- a/packages/playground/src/components/oklch/features/ColorBlindnessPreview.tsx
+++ b/packages/playground/src/components/oklch/features/ColorBlindnessPreview.tsx
@@ -32,34 +32,55 @@ const CVD_TYPES = {
 type CVDType = keyof typeof CVD_TYPES;
 
 /**
- * Color blindness simulation matrices (Brettel, Viénot & Mollon, 1997)
- * These matrices transform linear RGB values to simulate different types of CVD.
+ * Protanopia / deuteranopia simulation matrices — Viénot, Brettel & Mollon
+ * (1999), "Digital video colourmaps for checking the legibility of displays by
+ * dichromats", Color Research & Application 24(4). Each is a single 3x3
+ * projection applied in LINEAR RGB (sRGB decoded to linear light).
  *
- * The matrices work on linearized sRGB values and simulate the loss of
- * specific cone types in the human eye.
+ * Exact precomputed values from libDaltonLens (public domain / Unlicense),
+ * Nicolas Burrus — https://github.com/DaltonLens/libDaltonLens
+ * (`dl_vienot_protan_rgbCvd_from_rgb`, `dl_vienot_deutan_rgbCvd_from_rgb`).
+ * Viénot 1999 is not accurate for tritanopia; tritan uses Brettel 1997 below.
  */
-const CVD_MATRICES: Record<Exclude<CVDType, "achromatopsia">, number[][]> = {
-	// Protanopia: L-cone (long wavelength/red) deficiency
-	// Projects colors onto the plane visible to M and S cones only
+const VIENOT_1999_MATRICES: Record<"protanopia" | "deuteranopia", number[][]> = {
 	protanopia: [
-		[0.567, 0.433, 0.0],
-		[0.558, 0.442, 0.0],
-		[0.0, 0.242, 0.758],
+		[0.11238, 0.88762, 0.0],
+		[0.11238, 0.88762, 0.0],
+		[0.00401, -0.00401, 1.0],
 	],
-	// Deuteranopia: M-cone (medium wavelength/green) deficiency
-	// Projects colors onto the plane visible to L and S cones only
 	deuteranopia: [
-		[0.625, 0.375, 0.0],
-		[0.7, 0.3, 0.0],
-		[0.0, 0.3, 0.7],
+		[0.29275, 0.70725, 0.0],
+		[0.29275, 0.70725, 0.0],
+		[-0.02234, 0.02234, 1.0],
 	],
-	// Tritanopia: S-cone (short wavelength/blue) deficiency
-	// Projects colors onto the plane visible to L and M cones only
-	tritanopia: [
-		[0.95, 0.05, 0.0],
-		[0.0, 0.433, 0.567],
-		[0.0, 0.475, 0.525],
+};
+
+/**
+ * Tritanopia simulation — Brettel, Viénot & Mollon (1997), "Computerized
+ * simulation of color appearance for dichromats", JOSA A 14(10). Tritanopia is
+ * not a single linear projection: the gamut splits along a separation plane and
+ * each half-plane uses its own 3x3 matrix, selected per color by the sign of
+ * the dot product with the plane normal. All operate in LINEAR RGB.
+ *
+ * Exact precomputed values from libDaltonLens (public domain / Unlicense),
+ * Nicolas Burrus — https://github.com/DaltonLens/libDaltonLens.
+ */
+const BRETTEL_1997_TRITAN: {
+	plane1: number[][];
+	plane2: number[][];
+	separationNormal: number[];
+} = {
+	plane1: [
+		[1.01277, 0.13548, -0.14826],
+		[-0.01243, 0.86812, 0.14431],
+		[0.07589, 0.805, 0.11911],
 	],
+	plane2: [
+		[0.93678, 0.18979, -0.12657],
+		[0.06154, 0.81526, 0.1232],
+		[-0.37562, 1.12767, 0.24796],
+	],
+	separationNormal: [0.03901, -0.02788, -0.01113],
 };
 
 /**
@@ -93,36 +114,48 @@ function applyMatrix(rgb: [number, number, number], matrix: number[][]): [number
 }
 
 /**
- * Simulate how a color appears to someone with a specific color vision deficiency.
+ * Brettel 1997 tritanopia projection: pick the half-plane matrix by the sign of
+ * the dot product between the linear-RGB color and the separation-plane normal.
+ */
+function simulateTritanopia(linearRgb: [number, number, number]): [number, number, number] {
+	const { plane1, plane2, separationNormal } = BRETTEL_1997_TRITAN;
+	const dot =
+		linearRgb[0] * separationNormal[0] +
+		linearRgb[1] * separationNormal[1] +
+		linearRgb[2] * separationNormal[2];
+	return applyMatrix(linearRgb, dot >= 0 ? plane1 : plane2);
+}
+
+/**
+ * Simulate how a color appears to someone with a specific color vision
+ * deficiency. All simulation happens in LINEAR RGB: decode sRGB -> linear,
+ * transform, then re-encode to sRGB.
  *
- * For red-green deficiencies (protanopia, deuteranopia, tritanopia):
- * Uses Brettel et al. matrices which are widely used in accessibility tools.
- *
- * For achromatopsia (complete color blindness):
- * Uses luminance-weighted grayscale based on human perception weights.
+ * - Protanopia / deuteranopia: Viénot 1999 matrices (VIENOT_1999_MATRICES).
+ * - Tritanopia: Brettel 1997 dual half-plane projection (simulateTritanopia).
+ * - Achromatopsia: Rec. 709 luminance computed in LINEAR light, then re-encoded
+ *   (computing the weighted sum on gamma-encoded values gives the wrong gray).
  */
 function simulateCVD(color: Color, type: CVDType): string {
 	const rgb = color.toRgb();
-
-	if (type === "achromatopsia") {
-		// Complete color blindness - convert to grayscale using perceptual weights
-		// ITU-R BT.709 luminance coefficients (same as sRGB primaries)
-		const gray = Math.round(0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b);
-		return `rgb(${gray}, ${gray}, ${gray})`;
-	}
-
-	// Linearize RGB values for accurate color transformation
 	const linearRgb: [number, number, number] = [
 		srgbToLinear(rgb.r),
 		srgbToLinear(rgb.g),
 		srgbToLinear(rgb.b),
 	];
 
-	// Apply the CVD simulation matrix
-	const matrix = CVD_MATRICES[type];
-	const simulated = applyMatrix(linearRgb, matrix);
+	if (type === "achromatopsia") {
+		// Rec. 709 luminance in linear space, then re-encode to sRGB.
+		const y = 0.2126 * linearRgb[0] + 0.7152 * linearRgb[1] + 0.0722 * linearRgb[2];
+		const gray = linearToSrgb(y);
+		return `rgb(${gray}, ${gray}, ${gray})`;
+	}
 
-	// Convert back to sRGB
+	const simulated =
+		type === "tritanopia"
+			? simulateTritanopia(linearRgb)
+			: applyMatrix(linearRgb, VIENOT_1999_MATRICES[type]);
+
 	const r = linearToSrgb(simulated[0]);
 	const g = linearToSrgb(simulated[1]);
 	const b = linearToSrgb(simulated[2]);

--- a/packages/playground/src/components/oklch/features/PaletteGenerator.tsx
+++ b/packages/playground/src/components/oklch/features/PaletteGenerator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { type Color, color, contrast } from "use-color";
+import { type Color, clampToGamut, color, contrast } from "use-color";
 
 export interface PaletteGeneratorProps {
 	baseColor: Color;
@@ -38,24 +38,30 @@ export function PaletteGenerator({ baseColor, onColorSelect }: PaletteGeneratorP
 		for (let i = 0; i < steps; i++) {
 			const t = i / (steps - 1);
 
+			// Gamut-map every step into sRGB so the displayed swatch (from toHex(),
+			// which clamps) and the exported oklch() CSS (from toOklchString())
+			// describe the same displayable color instead of diverging on
+			// out-of-gamut values.
 			switch (paletteType) {
 				case "lightness": {
 					// L: 0.95 → 0.15 (light to dark, like Tailwind 100-900)
 					const l = 0.95 - t * 0.8;
-					colors.push(color({ l, c: oklch.c, h: oklch.h, a: oklch.a }));
+					colors.push(color(clampToGamut({ l, c: oklch.c, h: oklch.h, a: oklch.a })));
 					break;
 				}
 				case "chroma": {
 					// C: 0 → maxChroma (capped at 0.4 for sRGB gamut safety)
 					const maxChroma = Math.min(oklch.c * 1.5, 0.4);
 					const c = t * maxChroma;
-					colors.push(color({ l: oklch.l, c, h: oklch.h, a: oklch.a }));
+					colors.push(color(clampToGamut({ l: oklch.l, c, h: oklch.h, a: oklch.a })));
 					break;
 				}
 				case "hue": {
-					// H: baseHue → baseHue + 360° (full rotation)
-					const h = (oklch.h + t * 360) % 360;
-					colors.push(color({ l: oklch.l, c: oklch.c, h, a: oklch.a }));
+					// H: baseHue → baseHue + 360°·(steps-1)/steps. Stopping short of a
+					// full turn keeps the first and last swatches distinct (a full 360°
+					// is congruent to 0° and would duplicate the base hue).
+					const h = (oklch.h + (i / steps) * 360) % 360;
+					colors.push(color(clampToGamut({ l: oklch.l, c: oklch.c, h, a: oklch.a })));
 					break;
 				}
 			}

--- a/packages/playground/src/hooks/use-oklch-draft.ts
+++ b/packages/playground/src/hooks/use-oklch-draft.ts
@@ -75,7 +75,10 @@ export function useOklchDraft(
 	});
 
 	const baseOklchRef = useRef<OklchDraft | null>(baseColor ? colorToOklchDraft(baseColor) : null);
-	const baseColorKey = baseColor?.toHex8() ?? null;
+	// Change-detection key must be lossless: keying on toHex8() collapsed
+	// distinct out-of-gamut OKLCH commits that clamp to the same 8-bit hex,
+	// so the hook skipped re-syncing and Reset restored a stale color.
+	const baseColorKey = baseColor ? JSON.stringify(baseColor.toOklch()) : null;
 	const prevBaseKeyRef = useRef<string | null>(baseColorKey);
 
 	useEffect(() => {


### PR DESCRIPTION
Ultracode audit fix series (PR 8/10). **Stacked on the P3-E PR.**

Fixes audit items 3.9–3.13 (playground feature panels):
- **3.9** WCAG badge now actually grades contrast against 4.5 (normal) / 3.0 (large text) with separate badges.
- **3.10** Colorblind simulation rebuilt: Viénot 1999 matrices (protanopia/deuteranopia) and Brettel 1997 dual half-plane projection for tritanopia (exact libDaltonLens precomputed values, cited), all applied in **linear RGB** (decode → transform → re-encode). Achromatopsia uses Rec. 709 luminance in linear light. Replaces unattributed ColorJack approximations that ran partly in gamma space.
- **3.11** APCA thresholds use the standard Lc tiers (90/75/60/45/30/15).
- **3.12** "Apply" now commits the `oklch()` string instead of gamut-crushing through sRGB hex.
- **3.13** PaletteGenerator: hue steps no longer duplicate first/last swatch; every palette step is gamut-mapped so the displayed swatch and "Copy CSS" output agree.

Evidence: playground `tsc --noEmit` clean, `next build` compiles, `biome check` clean. Opus reviewer verdict: pass. Matrices independently spot-checked against libDaltonLens reference values.